### PR TITLE
Exhibit data

### DIFF
--- a/app/classes/pageHelpers.jsx
+++ b/app/classes/pageHelpers.jsx
@@ -1,4 +1,6 @@
 import { Link } from "remix"
+
+
 function renderAuthorBubble(author, boxAttach=false){
   let classes = "author-bubble"
   if(boxAttach){
@@ -13,7 +15,8 @@ function renderAuthorBubble(author, boxAttach=false){
 
 function renderPageLink(pageType, page){
   console.log( 'exxx', page )
-  let authorBubble = renderAuthorBubble(page.author, true)
+  // TODO render author bubble for each author in authors
+  let authorBubble = renderAuthorBubble(page.authors[0], true)
   return (
     <div className="pagelink">
       <a href={ '/' + pageType + '/' + page.id }>
@@ -22,7 +25,7 @@ function renderPageLink(pageType, page){
 
         { authorBubble }
 
-        <div className="pagelink-subtitle">By { page.author.name }</div>
+        <div className="pagelink-subtitle">By { page.authors[0].name }</div>
       </a>
     </div>
   )

--- a/app/exhibit.jsx
+++ b/app/exhibit.jsx
@@ -1,10 +1,14 @@
+import { json } from "@remix-run/node"
+import { exhibit } from '~/exhibit_data'
+
 export async function getExhibits() {
-  // how you get just exhibits 
-  return await fetch("http://localhost:8000/api/v2/pages", (res) => {
+  // how you get just exhibits
+  return await fetch(process.env.OV_API_URL + '/api/v2/exhibit/', res => {
     console.log(res)
   })
+  // return exhibit
 }
 
 export async function getExhibit(id) {
-  return await fetch("http://localhost:8000/api/v2/pages/" + id)
+  return await fetch(process.env.OV_API_URL + '/api/v2/exhibit/' + id)
 }

--- a/app/exhibit_data.jsx
+++ b/app/exhibit_data.jsx
@@ -1,0 +1,133 @@
+exhibits = {
+  meta: {
+    total_count: 5,
+  },
+  items: [
+    {
+      id: 4,
+      meta: {
+        type: 'exhibit.ExhibitPage',
+        detail_url: 'http://localhost:8000/api/v2/pages/4/',
+      },
+      title:
+        'ZOOM (1972-1978): Children’s Community and Public Television in the 1970s',
+      hero_thumb: {
+        url: '/media/images/Zoom_mainimage.2e16d0ba.fill-480x270.png',
+        width: 480,
+        height: 270,
+        alt: 'Zoom_mainimage',
+      },
+      authors: [
+        {
+          id: 2,
+          meta: {
+            type: 'authors.AuthorsOrderable',
+          },
+          name: 'Leslie Paris',
+          image: {
+            url: '/media/original_images/paris.png',
+            title: 'paris',
+            width: 534,
+            height: 576,
+          },
+        },
+      ],
+    },
+    {
+      id: 5,
+      meta: {
+        type: 'exhibit.ExhibitPage',
+        detail_url: 'http://localhost:8000/api/v2/pages/5/',
+      },
+      title: 'Innovations in Children’s Public Television Programming',
+      hero_thumb: null,
+      authors: [
+        {
+          id: 1,
+          meta: {
+            type: 'authors.AuthorsOrderable',
+          },
+          name: 'Leslie Paris',
+          image: {
+            url: '/media/original_images/paris.png',
+            title: 'paris',
+            width: 534,
+            height: 576,
+          },
+        },
+      ],
+    },
+    {
+      id: 6,
+      meta: {
+        type: 'exhibit.ExhibitPage',
+        detail_url: 'http://localhost:8000/api/v2/pages/6/',
+      },
+      title: 'Children as Cultural Producers',
+      hero_thumb: null,
+      authors: [
+        {
+          id: 3,
+          meta: {
+            type: 'authors.AuthorsOrderable',
+          },
+          name: 'Leslie Paris',
+          image: {
+            url: '/media/original_images/paris.png',
+            title: 'paris',
+            width: 534,
+            height: 576,
+          },
+        },
+      ],
+    },
+    {
+      id: 7,
+      meta: {
+        type: 'exhibit.ExhibitPage',
+        detail_url: 'http://localhost:8000/api/v2/pages/7/',
+      },
+      title: 'The Politics of ZOOM',
+      hero_thumb: null,
+      authors: [
+        {
+          id: 5,
+          meta: {
+            type: 'authors.AuthorsOrderable',
+          },
+          name: 'Leslie Paris',
+          image: {
+            url: '/media/original_images/paris.png',
+            title: 'paris',
+            width: 534,
+            height: 576,
+          },
+        },
+      ],
+    },
+    {
+      id: 8,
+      meta: {
+        type: 'exhibit.ExhibitPage',
+        detail_url: 'http://localhost:8000/api/v2/pages/8/',
+      },
+      title: 'Notes',
+      hero_thumb: null,
+      authors: [
+        {
+          id: 4,
+          meta: {
+            type: 'authors.AuthorsOrderable',
+          },
+          name: 'Leslie Paris',
+          image: {
+            url: '/media/original_images/paris.png',
+            title: 'paris',
+            width: 534,
+            height: 576,
+          },
+        },
+      ],
+    },
+  ],
+}

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -5,7 +5,7 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-  Link  
+  Link
 } from "remix";
 
 import NavigationBar from "./classes/navigationBar"

--- a/app/routes/exhibits/$exhibitId.jsx
+++ b/app/routes/exhibits/$exhibitId.jsx
@@ -13,7 +13,7 @@ export const loader = async ( { params } ) => {
 
 export default function Exhibits() {
 
-  // const exhibit = useLoaderData()
+  const exhibit = useLoaderData()
 
   let sidebar
   if(exhibit.sections){

--- a/app/routes/exhibits/$exhibitId.jsx
+++ b/app/routes/exhibits/$exhibitId.jsx
@@ -3,102 +3,18 @@ import { getExhibit } from "~/exhibit"
 import { renderAuthorBubble, renderPageLink, renderPageLinks, renderSidebar, renderSidebarSection, renderPageTitleBar } from "~/classes/pageHelpers"
 
 
-// commented out so we can use fake data
-// export const loader = async ( { params } ) => {
-//   console.log( 'exx id ', params )
-//   return await getExhibit( params.exhibitId )
-// }
+export const loader = async ( { params } ) => {
+  // fake data loader
+  // import { exhibits } from '~/exhibit_data'
+  // return exhibits.items[0]
+  console.log( 'exx id ', params )
+  return await getExhibit( params.exhibitId )
+}
 
 export default function Exhibits() {
-  const exhibit = {
-    id: 8,
-    meta: {
-      type: 'exhibit.ExhibitPage',
-      detail_url: 'http://localhost/api/v2/pages/8/',
-      html_url: 'http://localhost/bibg-boy-pages/',
-      slug: 'bibg-boy-pages',
-      show_in_menus: false,
-      seo_title: '',
-      search_description: '',
-      first_published_at: '2022-03-28T19:03:49.853855Z',
-      parent: { id: 3, meta: [Object], title: 'GBH Openvault' }
-    },
-    title: 'bibg boy pages',
-    body: '<p data-block-key="ggph3">yeah</p><p data-block-key="f78tu"></p><h2 id="section-6e2r2" data-block-key="6e2r2">but like yeah yeah <b>yeahhhhh</b></h2><p data-block-key="f14fo"></p><p data-block-key="flnk6"></p><p data-block-key="5eaeg"></p><p data-block-key="6tij5">but when you thinka bout it</p><p data-block-key="6tij5">but when you thinka bout it</p><p data-block-key="6tij5">but when you thinka bout it</p><p data-block-key="ot8u"></p><p data-block-key="bnien"></p><h2 id="section-fakey" data-block-key="fakey">what about a little bit of this!!!</h2><embed alt="flutin" embedtype="image" format="left" id="2"/><p data-block-key="dqprf"></p><p data-block-key="agdi8"></p><p data-block-key="32oee">right?</p>',
 
-    // hypothetical with anchors
-    sections: [
-      {id: "section-6e2r2", title: "Section 1"},
-      {id: "section-fakey", title: "Section 2"},
-    ],
-
-    // images
-    cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-    hero_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_35-89d51nbw.jpg',
-
-    // author information
-    author: {
-      name: "Coolman Slick",
-      image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Staff_Carter.jpg"
-    },
-
-    related_exhibits: [
-      {
-        id: 6,
-        meta: {
-          type: 'exhibit.ExhibitPage',
-          detail_url: 'http://localhost/api/v2/pages/6/',
-          html_url: 'http://localhost/wewf-sdfsdf/',
-          slug: 'wewf-sdfsdf',
-          first_published_at: '2022-03-28T18:28:32.842202Z'
-        },
-        title: 'wewf  sdfsdf',
-        cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-
-        author: {
-          name: "Weakman Wack",
-          image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Alexandra-Garcia.jpg"
-        }
-      },
-      {
-        id: 7,
-        meta: {
-          type: 'exhibit.ExhibitPage',
-          detail_url: 'http://localhost/api/v2/pages/7/',
-          html_url: 'http://localhost/holy-heck/',
-          slug: 'holy-heck',
-          first_published_at: '2022-03-28T18:28:32.842202Z'
-        },
-        title: 'holy heck',
-        cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-
-        author: {
-          name: "Coolman Slick",
-          image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Staff_Carter.jpg"
-        }
-      },
-      {
-        id: 8,
-        meta: {
-          type: 'exhibit.ExhibitPage',
-          detail_url: 'http://localhost/api/v2/pages/8/',
-          html_url: 'http://localhost/wowie-zowie/',
-          slug: 'wowie-zowie',
-          first_published_at: '2022-03-28T18:28:32.842202Z'
-        },
-        title: 'wowie zowie',
-        cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-
-        author: {
-          name: "Just Alright, Esq.",
-          image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Staff_Curtis.jpg"
-        }
-      },
-    ]
-
-  }
   // const exhibit = useLoaderData()
-  
+
   let sidebar
   if(exhibit.sections){
     sidebar = renderSidebar("exhibit", exhibit.sections)
@@ -124,11 +40,11 @@ export default function Exhibits() {
               <Link className="page-nav-link" to="/exhibits" >View all scholar exhibits ></Link>
             </div>
           </div>
-        
+
           { renderPageLinks('exhibits', exhibit.related_exhibits) }
         </div>
       </div>
-    ) 
+    )
   }
 
   let exhibitAuthor
@@ -155,7 +71,7 @@ export default function Exhibits() {
           { exhibitAuthor }
           <div className="page-body" dangerouslySetInnerHTML={{ __html: exhibit.body }} />
         </div>
-        
+
         { bottomBar }
       </div>
     </div>
@@ -166,4 +82,3 @@ function scrollSectionIntoView(section){
   let ele = document.getElementById(section.id)
   ele.scrollIntoView()
 }
-

--- a/app/routes/exhibits/index.jsx
+++ b/app/routes/exhibits/index.jsx
@@ -3,72 +3,20 @@ import { getExhibits } from "~/exhibit"
 import { renderAuthorBubble, renderPageLink, renderPageLinks } from "~/classes/pageHelpers"
 
 // // commented out so we can use fake data
-// export const loader = async () => {
-//   return await getExhibits()
-// }
+export const loader = async () => {
+  return await getExhibits()
+}
 
 export default function Exhibits() {
   let exhibits
 
   // actually get from api
-  // exhibits = useLoaderData()
-  exhibits = [
-    {
-      id: 6,
-      meta: {
-        type: 'exhibit.ExhibitPage',
-        detail_url: 'http://localhost/api/v2/pages/6/',
-        html_url: 'http://localhost/wewf-sdfsdf/',
-        slug: 'wewf-sdfsdf',
-        first_published_at: '2022-03-28T18:28:32.842202Z'
-      },
-      title: 'wewf  sdfsdf',
-      cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
+  exhibits = useLoaderData()
 
-      author: {
-        name: "Weakman Wack",
-        image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Alexandra-Garcia.jpg"
-      }
-    },
-    {
-      id: 7,
-      meta: {
-        type: 'exhibit.ExhibitPage',
-        detail_url: 'http://localhost/api/v2/pages/7/',
-        html_url: 'http://localhost/holy-heck/',
-        slug: 'holy-heck',
-        first_published_at: '2022-03-28T18:28:32.842202Z'
-      },
-      title: 'holy heck',
-      cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-
-      author: {
-        name: "Coolman Slick",
-        image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Staff_Carter.jpg"
-      }
-    },
-    {
-      id: 8,
-      meta: {
-        type: 'exhibit.ExhibitPage',
-        detail_url: 'http://localhost/api/v2/pages/8/',
-        html_url: 'http://localhost/wowie-zowie/',
-        slug: 'wowie-zowie',
-        first_published_at: '2022-03-28T18:28:32.842202Z'
-      },
-      title: 'wowie zowie',
-      cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-
-      author: {
-        name: "Just Alright, Esq.",
-        image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Staff_Curtis.jpg"
-      }
-    },
-  ]
 
   console.log( 'ex', exhibits )
 
-  let exhibitLinks = renderPageLinks('exhibits', exhibits)
+  let exhibitLinks = renderPageLinks('exhibits', exhibits.items)
   return (
     <div className="pagelinks-container">
       { exhibitLinks }

--- a/app/routes/exhibits/index.jsx
+++ b/app/routes/exhibits/index.jsx
@@ -2,17 +2,13 @@ import { Link, useLoaderData } from "remix"
 import { getExhibits } from "~/exhibit"
 import { renderAuthorBubble, renderPageLink, renderPageLinks } from "~/classes/pageHelpers"
 
-// // commented out so we can use fake data
 export const loader = async () => {
   return await getExhibits()
 }
 
 export default function Exhibits() {
-  let exhibits
 
-  // actually get from api
-  exhibits = useLoaderData()
-
+  let exhibits = useLoaderData()
 
   console.log( 'ex', exhibits )
 

--- a/app/routes/index.jsx
+++ b/app/routes/index.jsx
@@ -1,67 +1,17 @@
-import { Link } from "remix"
+import { Link, useLoaderData } from "remix"
 import { Carousel } from "react-responsive-carousel"
 import { renderPageLinks } from "~/classes/pageHelpers"
+import { getExhibits } from "~/exhibit"
+
+export function loader() {
+  return getExhibits()
+}
 
 export default function Index() {
-
-  // need loader!
-  let exhibits 
-  exhibits = [
-      {
-        id: 6,
-        meta: {
-          type: 'exhibit.ExhibitPage',
-          detail_url: 'http://localhost/api/v2/pages/6/',
-          html_url: 'http://localhost/wewf-sdfsdf/',
-          slug: 'wewf-sdfsdf',
-          first_published_at: '2022-03-28T18:28:32.842202Z'
-        },
-        title: 'wewf  sdfsdf',
-        cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-
-        author: {
-          name: "Weakman Wack",
-          image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Alexandra-Garcia.jpg"
-        }
-      },
-      {
-        id: 7,
-        meta: {
-          type: 'exhibit.ExhibitPage',
-          detail_url: 'http://localhost/api/v2/pages/7/',
-          html_url: 'http://localhost/holy-heck/',
-          slug: 'holy-heck',
-          first_published_at: '2022-03-28T18:28:32.842202Z'
-        },
-        title: 'holy heck',
-        cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-
-        author: {
-          name: "Coolman Slick",
-          image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Staff_Carter.jpg"
-        }
-      },
-      {
-        id: 8,
-        meta: {
-          type: 'exhibit.ExhibitPage',
-          detail_url: 'http://localhost/api/v2/pages/8/',
-          html_url: 'http://localhost/wowie-zowie/',
-          slug: 'wowie-zowie',
-          first_published_at: '2022-03-28T18:28:32.842202Z'
-        },
-        title: 'wowie zowie',
-        cover_image: 'https://s3.amazonaws.com/americanarchive.org/cpb-aacip_111-451g1rhp.jpg',
-
-        author: {
-          name: "Just Alright, Esq.",
-          image_url: "https://s3.amazonaws.com/americanarchive.org/staff/Staff_Curtis.jpg"
-        }
-      },
-    ]
+  const exhibits = useLoaderData()
 
 
-  let exhibitLinks = renderPageLinks('exhibits', exhibits)
+  let exhibitLinks = renderPageLinks('exhibits', exhibits.items)
 
   return (
     <div className="home-container">


### PR DESCRIPTION
# Exhibit data
- Moved data fixture to `exhibit_data.jsx` for frontend testing
- Live loads data from API (in deploy)
- Refactor routes for new `ExhibitAPI` data model
- Refactor `author` to `authors[0]` for simplicity
  - Will need to convert to `authors.forEach()` 

First working integration with [ov_deploy](https://github.com/WGBH-MLA/ov_deploy/)!!!