### PR TITLE
🥳 Include new label names in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,21 +2,21 @@ changelog:
   categories:
     - title: Breaking Changes 🪅
       labels:
-        - 'breaking :broken_heart:'
+        - 'breaking 💔'
 
     - title: New Features 🎉
       labels:
-        - 'enhancement :heavy_plus_sign:'
+        - 'enhancement ➕'
 
-    - title: 'Bugfixes :bug:'
+    - title: 'Bugfixes 🐛'
       labels:
-        - 'bug :bug:'
+        - 'bug 🐛'
 
-    - title: 'Maintenance :nut_and_bolt:'
+    - title: 'Maintenance 🔩'
       labels:
-        - 'maintenance :wrench:'
-        - 'CI :test_tube:'
-        - 'CD :building_construction:'
+        - 'maintenance 🔧'
+        - 'CI 🦾'
+        - 'CD 🏗️'
 
     - title: Other Changes
       labels:


### PR DESCRIPTION
# Release labels
With [ov-deploy PR#39](https://github.com/WGBH-MLA/ov-deploy/pull/39)

Because  github's `:emoji:` syntax does not show up Zenhub, this migrates all ov-* labels to use emojis directly.

This PR changes the release notes to match the current labels.