### PR TITLE
🫧 Elastic errors

### DIFF
--- a/app/classes/search-ui.tsx
+++ b/app/classes/search-ui.tsx
@@ -67,8 +67,8 @@ export const Search = ({ serverState, serverUrl, aapb_host }: SearchProps) => {
                 <NoResultsBoundary fallback={<NoResults />}>
                   <h2>Open Vault results</h2>
                   <Refinements />
-                  <Hits hitComponent={Hit} />
-                  <Pagination />
+                  {/* <Hits hitComponent={Hit} /> */}
+                  {/* <Pagination /> */}
                   Results per page
                   <HitsPerPage
                     items={[
@@ -83,7 +83,7 @@ export const Search = ({ serverState, serverUrl, aapb_host }: SearchProps) => {
               <Index indexName="gbh-series">
                 <NoResultsBoundary fallback={null}>
                   <h3>GBH Series results</h3>
-                  <Carousel aapb_host={aapb_host} />
+                  {/* <Carousel aapb_host={aapb_host} /> */}
                 </NoResultsBoundary>
               </Index>
             </EmptyQueryBoundary>

--- a/app/classes/search-ui.tsx
+++ b/app/classes/search-ui.tsx
@@ -10,6 +10,7 @@ import {
   HitsPerPage,
 } from 'react-instantsearch'
 import {
+  Error,
   EmptyQueryBoundary,
   NoResultsBoundary,
   LoadingIndicator,
@@ -52,6 +53,7 @@ export const Search = ({ serverUrl, aapb_host }: SearchProps) => {
           }}
           className="search-box"
         />
+        <Error />
         <div className="search-results">
           <EmptyQueryBoundary fallback={<EmptyQueryMessage />}>
             <AAPBResults aapb_host={aapb_host} />

--- a/app/classes/search-ui.tsx
+++ b/app/classes/search-ui.tsx
@@ -6,18 +6,15 @@ import {
   SearchBox,
   Hits,
   Index,
-  InstantSearchSSRProvider,
   Pagination,
   HitsPerPage,
 } from 'react-instantsearch'
 import {
-  Error,
   EmptyQueryBoundary,
   NoResultsBoundary,
   LoadingIndicator,
   EmptyQueryMessage,
 } from './search-utils'
-import { SearchErrorToast } from '../components/SearchErrorToast'
 import { ScrollTo } from '../components/ScrollTo'
 import { Hit } from '../components/Hit'
 import { Carousel } from '../components/Carousel'
@@ -32,64 +29,59 @@ const sk = new Searchkit(searchkit_options)
 export const searchClient = Client(sk)
 console.log('searchClient', searchClient)
 
-export const Search = ({ serverState, serverUrl, aapb_host }: SearchProps) => {
+export const Search = ({ serverUrl, aapb_host }: SearchProps) => {
   let timerId
   let timeout = 350
 
   return (
-    <InstantSearchSSRProvider {...serverState}>
-      <InstantSearch
-        searchClient={searchClient}
-        routing={{
-          router: Router(serverUrl),
-          stateMapping: { stateToRoute, routeToState },
-        }}
-        insights={false}
-      >
-        <Error />
-        <SearchErrorToast />
-
-        <ScrollTo className="max-w-6xl p-4 flex gap-4 m-auto">
-          <SearchBox
-            queryHook={(query, refine) => {
-              // console.log('searchbox', query)
-              // debounce the search input box
-              clearTimeout(timerId)
-              timerId = setTimeout(() => refine(query), timeout)
-            }}
-            className="search-box"
-          />
-          <div className="search-results">
-            <EmptyQueryBoundary fallback={<EmptyQueryMessage />}>
-              <AAPBResults aapb_host={aapb_host} />
-              <LoadingIndicator />
-              <Index indexName="wagtail__wagtailcore_page">
-                <NoResultsBoundary fallback={<NoResults />}>
-                  <h2>Open Vault results</h2>
-                  <Refinements />
-                  {/* <Hits hitComponent={Hit} /> */}
-                  {/* <Pagination /> */}
-                  Results per page
-                  <HitsPerPage
-                    items={[
-                      { value: 5, label: '5' },
-                      { value: 10, label: '10', default: true },
-                      { value: 20, label: '20' },
-                      { value: 50, label: '50' },
-                    ]}
-                  />
-                </NoResultsBoundary>
-              </Index>
-              <Index indexName="gbh-series">
-                <NoResultsBoundary fallback={null}>
-                  <h3>GBH Series results</h3>
-                  {/* <Carousel aapb_host={aapb_host} /> */}
-                </NoResultsBoundary>
-              </Index>
-            </EmptyQueryBoundary>
-          </div>
-        </ScrollTo>
-      </InstantSearch>
-    </InstantSearchSSRProvider>
+    <InstantSearch
+      searchClient={searchClient}
+      routing={{
+        router: Router(serverUrl),
+        stateMapping: { stateToRoute, routeToState },
+      }}
+      insights={false}
+    >
+      <ScrollTo className="max-w-6xl p-4 flex gap-4 m-auto">
+        <SearchBox
+          queryHook={(query, refine) => {
+            // console.log('searchbox', query)
+            // debounce the search input box
+            clearTimeout(timerId)
+            timerId = setTimeout(() => refine(query), timeout)
+          }}
+          className="search-box"
+        />
+        <div className="search-results">
+          <EmptyQueryBoundary fallback={<EmptyQueryMessage />}>
+            <AAPBResults aapb_host={aapb_host} />
+            <LoadingIndicator />
+            <Index indexName="wagtail__wagtailcore_page">
+              <NoResultsBoundary fallback={<NoResults />}>
+                <h2>Open Vault results</h2>
+                <Refinements />
+                <Hits hitComponent={Hit} />
+                <Pagination />
+                Results per page
+                <HitsPerPage
+                  items={[
+                    { value: 5, label: '5' },
+                    { value: 10, label: '10', default: true },
+                    { value: 20, label: '20' },
+                    { value: 50, label: '50' },
+                  ]}
+                />
+              </NoResultsBoundary>
+            </Index>
+            <Index indexName="gbh-series">
+              <NoResultsBoundary fallback={null}>
+                <h3>GBH Series results</h3>
+                <Carousel aapb_host={aapb_host} />
+              </NoResultsBoundary>
+            </Index>
+          </EmptyQueryBoundary>
+        </div>
+      </ScrollTo>
+    </InstantSearch>
   )
 }

--- a/app/classes/search-utils.jsx
+++ b/app/classes/search-utils.jsx
@@ -9,7 +9,7 @@ export function Error() {
   const { error } = useInstantSearch({ catchError: true })
 
   if (error) {
-    return <>Search error: {error.message}</>
+    throw error
   }
 }
 

--- a/app/components/Carousel.tsx
+++ b/app/components/Carousel.tsx
@@ -1,8 +1,6 @@
-import { useInstantSearch } from 'react-instantsearch-core'
 import { Highlight, Hits } from 'react-instantsearch'
 
 export const Carousel = ({ aapb_host }) => {
-  const { results } = useInstantSearch()
   const aapb_link = (title) => `${aapb_host}/catalog?f[series_titles][]=${title}&q=+(contributing_organizations: WGBH(MA) OR producing_organizations: WGBH Educational Foundation)&f[access_types][]=all`
 
   const SeriesHit = ({ hit }) => {

--- a/app/components/Hit.tsx
+++ b/app/components/Hit.tsx
@@ -5,6 +5,7 @@ type HitProps = {
   hit: AlgoliaHit<{
     objectID: number
     title: string
+    slug: string
   }>
 }
 
@@ -13,12 +14,12 @@ export const Hit = ({ hit }: HitProps) => {
   switch (true) {
     case 'exhibits_exhibitpage__body_edgengrams' in hit:
       label = 'Scholar Exhibit'
-      route = '/exhibits/' + hit.objectID
+      route = '/exhibits/' + hit.slug
       type = 'exhibit-tag'
       break
     case 'ov_collections_collection__introduction_edgengrams' in hit:
       label = 'Special Collection'
-      route = '/collections/' + hit.objectID
+      route = '/collections/' + hit.slug
       type = 'collection-tag'
       break
     default:

--- a/app/data/searchkit.json
+++ b/app/data/searchkit.json
@@ -6,12 +6,14 @@
   "search_settings": {
     "search_attributes": [
       { "field": "title", "weight": 3 },
+      "slug",
       "exhibits_exhibitpage__body_edgengrams",
       "ov_collections_collection__introduction_edgengrams",
       "featured"
     ],
     "result_attributes": [
       "title",
+      "slug",
       "exhibits_exhibitpage__body_edgengrams",
       "ov_collections_collection__introduction_edgengrams"
     ],

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -1,24 +1,17 @@
-import { renderToString } from 'react-dom/server'
-import {
-  RefinementList,
-  getServerState,
-  InstantSearchServerState,
-} from 'react-instantsearch'
+import { RefinementList, InstantSearchServerState } from 'react-instantsearch'
 import type { LoaderFunction, MetaFunction } from '@remix-run/node'
 import { json } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
+import { useLoaderData, useRouteError } from '@remix-run/react'
 import { Panel } from '../components/Panel'
 import { Search } from '../classes/search-ui'
 import 'instantsearch.css/themes/algolia-min.css'
 import '../styles/search.css'
 
 export const meta: MetaFunction = ({ location }) => {
-  const query = new URLSearchParams(
-    location.search
-  ).get("q")
+  const query = new URLSearchParams(location.search).get('q')
   return [
     {
-      title: `${query ? query + ' | ' : '' }Search GBH Open Vault`,
+      title: `${query ? query + ' | ' : ''}Search GBH Open Vault`,
     },
     {
       name: 'description',
@@ -30,16 +23,9 @@ export const meta: MetaFunction = ({ location }) => {
 
 export const loader: LoaderFunction = async ({ request }) => {
   const serverUrl = request.url
-  const aapb_host = process.env.AAPB_HOST || 'https://demo.aapb.wgbh-mla.org'
-  const serverState = await getServerState(
-    <Search serverUrl={serverUrl} aapb_host={aapb_host} />,
-    {
-      renderToString,
-    }
-  )
+  const aapb_host = process.env.AAPB_HOST
 
   return json({
-    serverState,
     serverUrl,
     aapb_host,
   })
@@ -54,18 +40,28 @@ function FallbackComponent({ attribute }: { attribute: string }) {
 }
 
 export type SearchProps = {
-  serverState?: InstantSearchServerState
   serverUrl?: URL
   aapb_host?: URL
 }
 
 export default function SearchPage() {
-  const { serverState, serverUrl, aapb_host }: SearchProps = useLoaderData()
+  const { serverUrl, aapb_host }: SearchProps = useLoaderData()
   return (
     <Search
-      serverState={serverState}
       serverUrl={serverUrl}
       aapb_host={aapb_host}
     />
+  )
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError()
+  console.log('search error', error)
+  return (
+    <div>
+      <h1>Search Error</h1>
+      <h4>We're sorry! Search appears to be broken!</h4>
+      <pre>{error.message}</pre>
+    </div>
   )
 }


### PR DESCRIPTION
# Search SSR
Removes server side rendering component for search because it was crashing the server on uncaught errors.

Closes #76

## TLDR
~Something about the `<Hits>` and `<Pagination>` components~
Error in `/search` route `loader` function when creating `InstantSearchSSRProvider` when there is an error fetching search data (i.e. elasticsearch SSL certificate is expired). This was hard crashing the production server when someone loaded the `/search` page.

## Misc
Fixes search result `<Hit>` links to use `slug`
Closes #77 

