### PR TITLE
🏷 `Open Graph` tags for social share preview

### DIFF
--- a/app/classes/meta.tsx
+++ b/app/classes/meta.tsx
@@ -23,3 +23,26 @@ export const extractMeta = (server_url: URL, article: Article) => [
   },
   { property: 'twitter:image', content: article.cover_image.url },
 ]
+
+export const HomeMeta = [
+  // { property: 'og:url', content: 'https://openvault.wgbh.org' },
+  { property: 'og:type', content: 'website' },
+  { property: 'og:title', content: 'GBH Open Vault' },
+  {
+    property: 'og:description',
+    content: 'Explore Scholar Exhibits and Collections from GBH Open Vault',
+  },
+  { property: 'og:image', content: 'https://ov.wgbh-mla.org/gbh-mural.jpg' },
+  { name: 'twitter:card', content: 'summary_large_image' },
+  { property: 'twitter:domain', content: 'openvault.wgbh.org' },
+  // { property: 'twitter:url', content: 'https://openvault.wgbh.org' },
+  { property: 'twitter:title', content: 'GBH Open Vault Exhibit' },
+  {
+    property: 'twitter:description',
+    content: 'Explore Scholar Exhibits and Collections from GBH Open Vault',
+  },
+  {
+    property: 'twitter:image',
+    content: 'https://ov.wgbh-mla.org/gbh-mural.jpg',
+  },
+]

--- a/app/classes/meta.tsx
+++ b/app/classes/meta.tsx
@@ -1,0 +1,25 @@
+type Article = {
+  title: string
+  cover_image: { url: string }
+  meta: { search_description: string }
+}
+
+export const extractMeta = (server_url: URL, article: Article) => [
+  { property: 'og:url', content: server_url },
+  { property: 'og:type', content: 'article' },
+  { property: 'og:title', content: article.title },
+  {
+    property: 'og:description',
+    content: article.meta.search_description || 'GBH Open Vault Exhibit',
+  },
+  { property: 'og:image', content: article.cover_image.url },
+  { name: 'twitter:card', content: 'summary_large_image' },
+  { property: 'twitter:domain', content: 'openvault.wgbh.org' },
+  { property: 'twitter:url', content: server_url },
+  { property: 'twitter:title', content: article.title },
+  {
+    property: 'twitter:description',
+    content: article.meta.search_description || 'GBH Open Vault Exhibit',
+  },
+  { property: 'twitter:image', content: article.cover_image.url },
+]

--- a/app/classes/meta.tsx
+++ b/app/classes/meta.tsx
@@ -16,16 +16,16 @@ export const extractMeta = (server_url: URL, article: Article) => [
   { name: 'twitter:card', content: 'summary_large_image' },
   { property: 'twitter:domain', content: 'openvault.wgbh.org' },
   { property: 'twitter:url', content: server_url },
-  { property: 'twitter:title', content: article.title },
+  { name: 'twitter:title', content: article.title },
   {
-    property: 'twitter:description',
+    name: 'twitter:description',
     content: article.meta.search_description || 'GBH Open Vault Exhibit',
   },
-  { property: 'twitter:image', content: article.cover_image.url },
+  { name: 'twitter:image', content: article.cover_image.url },
 ]
 
 export const HomeMeta = [
-  // { property: 'og:url', content: 'https://openvault.wgbh.org' },
+  { property: 'og:url', content: 'https://openvault.wgbh.org' },
   { property: 'og:type', content: 'website' },
   { property: 'og:title', content: 'GBH Open Vault' },
   {
@@ -35,14 +35,14 @@ export const HomeMeta = [
   { property: 'og:image', content: 'https://ov.wgbh-mla.org/gbh-mural.jpg' },
   { name: 'twitter:card', content: 'summary_large_image' },
   { property: 'twitter:domain', content: 'openvault.wgbh.org' },
-  // { property: 'twitter:url', content: 'https://openvault.wgbh.org' },
-  { property: 'twitter:title', content: 'GBH Open Vault Exhibit' },
+  { property: 'twitter:url', content: 'https://openvault.wgbh.org' },
+  { name: 'twitter:title', content: 'GBH Open Vault Exhibit' },
   {
-    property: 'twitter:description',
+    name: 'twitter:description',
     content: 'Explore Scholar Exhibits and Collections from GBH Open Vault',
   },
   {
-    property: 'twitter:image',
+    name: 'twitter:image',
     content: 'https://ov.wgbh-mla.org/gbh-mural.jpg',
   },
 ]

--- a/app/classes/meta.tsx
+++ b/app/classes/meta.tsx
@@ -24,25 +24,26 @@ export const extractMeta = (server_url: URL, article: Article) => [
   { name: 'twitter:image', content: article.cover_image.url },
 ]
 
-export const HomeMeta = [
-  { property: 'og:url', content: 'https://openvault.wgbh.org' },
+export const Meta = [
   { property: 'og:type', content: 'website' },
-  { property: 'og:title', content: 'GBH Open Vault' },
-  {
-    property: 'og:description',
-    content: 'Explore Scholar Exhibits and Collections from GBH Open Vault',
-  },
   { property: 'og:image', content: 'https://ov.wgbh-mla.org/gbh-mural.jpg' },
   { name: 'twitter:card', content: 'summary_large_image' },
   { property: 'twitter:domain', content: 'openvault.wgbh.org' },
-  { property: 'twitter:url', content: 'https://openvault.wgbh.org' },
   { name: 'twitter:title', content: 'GBH Open Vault Exhibit' },
   {
     name: 'twitter:description',
     content: 'Explore Scholar Exhibits and Collections from GBH Open Vault',
   },
+  { name: 'twitter:image', content: 'https://ov.wgbh-mla.org/gbh-mural.jpg' },
+]
+
+export const HomeMeta = [
+  ...Meta,
+  { property: 'og:title', content: 'GBH Open Vault' },
+  { property: 'og:url', content: 'https://openvault.wgbh.org' },
+  { property: 'twitter:url', content: 'https://openvault.wgbh.org' },
   {
-    name: 'twitter:image',
-    content: 'https://ov.wgbh-mla.org/gbh-mural.jpg',
+    property: 'og:description',
+    content: 'Explore Scholar Exhibits and Collections from GBH Open Vault',
   },
 ]

--- a/app/classes/navigationBar.jsx
+++ b/app/classes/navigationBar.jsx
@@ -10,11 +10,11 @@ let aboutLinks = [
   },
   {
     label: 'Support Us',
-    url: '/supportus',
+    url: '/support-us',
   },
   {
     label: 'Visit Us',
-    url: '/visitus',
+    url: '/visit-us',
   },
   {
     label: 'FAQ',

--- a/app/fetch.jsx
+++ b/app/fetch.jsx
@@ -31,5 +31,5 @@ export async function getPageBySlug(type, slug) {
   }
   return await fetch(
     `${process.env.OV_API_URL}/api/v2/${type}/${body.items[0].id}`
-  )
+  ).then(res => res.json())
 }

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -10,6 +10,7 @@ import {
 } from '@remix-run/react'
 import { json } from '@remix-run/node'
 import { useEffect } from 'react'
+import { HomeMeta } from './classes/meta'
 
 import { NavigationBar } from './classes/navigationBar'
 import { Footer } from './classes/footer'
@@ -27,13 +28,12 @@ export function links() {
 
 export const meta = () => {
   return [
-    {
-      title: `GBH Open Vault`,
-    },
+    { title: `GBH Open Vault` },
     {
       name: 'description',
       content: `Explore scholar exhibits and collections from the GBH Archives.`,
     },
+    ...HomeMeta,
   ]
 }
 

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -53,7 +53,7 @@ export async function loader() {
 export default function App() {
   var data = useLoaderData()
   let meta = import.meta
-  console.log('meta', meta)
+  // console.log('meta', meta)
 
   if (meta.env && meta.env.LEGACY) {
     console.log('legacy browser detected')

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -37,8 +37,6 @@ export const meta = () => {
   ]
 }
 
-// const serverUrl = 'https://elastic.wgbh-mla.org';
-
 export async function loader() {
   // lift these env vars from process.env so they can be injected into window
   return json({

--- a/app/routes/about.jsx
+++ b/app/routes/about.jsx
@@ -1,4 +1,5 @@
-import { renderPageTitleBar } from "../classes/pageHelpers"
+import { renderPageTitleBar } from '../classes/pageHelpers'
+import { Meta } from '../classes/meta'
 
 export const meta = () => {
   return [
@@ -9,16 +10,21 @@ export const meta = () => {
       name: 'description',
       content: `Open Vault provides online access to unique and historically important content produced by GBH.`,
     },
+    ...Meta,
   ]
 }
 
 export default function About() {
-  let titleBar = renderPageTitleBar("About Open Vault", "https://s3.amazonaws.com/openvault.wgbh.org/carousel/discoverywoodsetcameraWide.jpg", "Open Vault provides online access to unique and historically important content produced by GBH.")
+  let titleBar = renderPageTitleBar(
+    'About Open Vault',
+    'https://s3.amazonaws.com/openvault.wgbh.org/carousel/discoverywoodsetcameraWide.jpg',
+    'Open Vault provides online access to unique and historically important content produced by GBH.'
+  )
 
   return (
     <div>
       <div className="page-container">
-        { titleBar }
+        {titleBar}
 
         <div className="page-sidebar" />
 
@@ -27,31 +33,68 @@ export default function About() {
             <h2>Welcome to Open Vault!</h2>
 
             <p className="static-section">
-              On this website, GBH Archives provides online access to unique and historically important content produced by the public television and radio station GBH. Open Vault contains video, audio, images, searchable transcripts, and resource management tools, all of which are available for individual and classroom learning.
+              On this website, GBH Archives provides online access to unique and
+              historically important content produced by the public television
+              and radio station GBH. Open Vault contains video, audio, images,
+              searchable transcripts, and resource management tools, all of
+              which are available for individual and classroom learning.
             </p>
             <p className="static-section">
-              As America's preeminent public broadcasting producer, the source of fully one-third of PBS' prime-time lineup, GBH has been on the front lines of history for nearly seven decades. GBH productions - from local radio and television to nationally distributed programming - have documented our collective cultural heritage in moving images and sound. In 1979, GBH became the first public broadcasting station to develop an archive, staffed by professional archivists. For more than 35 years, MLA staff have preserved, cataloged, and provided access to materials produced by GBH. We currently manage and preserve nearly 1 million audio, video, film, and digital assets dating back to 1947.
+              As America's preeminent public broadcasting producer, the source
+              of fully one-third of PBS' prime-time lineup, GBH has been on the
+              front lines of history for nearly seven decades. GBH productions -
+              from local radio and television to nationally distributed
+              programming - have documented our collective cultural heritage in
+              moving images and sound. In 1979, GBH became the first public
+              broadcasting station to develop an archive, staffed by
+              professional archivists. For more than 35 years, MLA staff have
+              preserved, cataloged, and provided access to materials produced by
+              GBH. We currently manage and preserve nearly 1 million audio,
+              video, film, and digital assets dating back to 1947.
             </p>
             <p className="static-section">
-              Open Vault contains video, audio, images, searchable transcripts, and resource management tools, all of which are available for individual and classroom learning. As America's preeminent public broadcasting producer, the source of fully one-third of PBS' prime-time lineup, GBH has been on the front lines of history for nearly seven decades. GBH productions - from local radio and television to nationally distributed programming - have documented our collective cultural heritage in moving images and sound. In 1979, GBH became the first public broadcasting station to develop an archive, staffed by professional archivists. For more than 35 years, MLA staff have preserved, cataloged, and provided access to materials produced by GBH. We currently manage and preserve nearly 1 million audio, video, film, and digital assets dating back to 1947.
+              Open Vault contains video, audio, images, searchable transcripts,
+              and resource management tools, all of which are available for
+              individual and classroom learning. As America's preeminent public
+              broadcasting producer, the source of fully one-third of PBS'
+              prime-time lineup, GBH has been on the front lines of history for
+              nearly seven decades. GBH productions - from local radio and
+              television to nationally distributed programming - have documented
+              our collective cultural heritage in moving images and sound. In
+              1979, GBH became the first public broadcasting station to develop
+              an archive, staffed by professional archivists. For more than 35
+              years, MLA staff have preserved, cataloged, and provided access to
+              materials produced by GBH. We currently manage and preserve nearly
+              1 million audio, video, film, and digital assets dating back to
+              1947.
             </p>
 
             <hr className="spaced-hr" />
 
-            <h2 className="static-link">American Archive of Public Broadcasting</h2>
-
+            <h2 className="static-link">
+              American Archive of Public Broadcasting
+            </h2>
 
             <p className="static-section">
               <img className="half-image right" src="/aapb.png" />
-
-              In 2013, the Corporation for Public Broadcasting selected GBH and the Library of Congress as the permanent stewards of the American Archive of Public Broadcasting, an initiative seeking to identify, preserve and make accessible significant historical content created by public media, and to preserve at-risk public media before its content is lost to posterity. Approximately 40,000 hours of content comprising 68,000 programs, contributed by 100 stations across the country, have been digitized. We provide access to nearly 12,000 of these programs, which are available online at americanarchive.org.
+              In 2013, the Corporation for Public Broadcasting selected GBH and
+              the Library of Congress as the permanent stewards of the American
+              Archive of Public Broadcasting, an initiative seeking to identify,
+              preserve and make accessible significant historical content
+              created by public media, and to preserve at-risk public media
+              before its content is lost to posterity. Approximately 40,000
+              hours of content comprising 68,000 programs, contributed by 100
+              stations across the country, have been digitized. We provide
+              access to nearly 12,000 of these programs, which are available
+              online at americanarchive.org.
             </p>
 
             <hr className="spaced-hr" />
 
             <h3 className="static-link">GBH Stock Sales</h3>
             <p className="static-section">
-              For professional licensing requests, please visit the GBH Stock Sales website or call 617-300-3939.
+              For professional licensing requests, please visit the GBH Stock
+              Sales website or call 617-300-3939.
             </p>
 
             <hr className="spaced-hr" />
@@ -59,37 +102,62 @@ export default function About() {
             <a className="static-link">Boston TV News Digital Library</a>
             <p className="static-section">
               <img className="half-image left" src="/tocn.png" />
-
-              You can explore more of GBH's collection in the Boston TV News Digital Library. During this CLIR and IMLS-funded project, we worked with the Boston Public Library, Cambridge Community Television, and Northeast Historic Film to digitize and bring to life local news stories produced in and about Boston from 1960 to 2000. Nearly 2,000 news programs are available online at BostonLocalTV.org.
-
+              You can explore more of GBH's collection in the Boston TV News
+              Digital Library. During this CLIR and IMLS-funded project, we
+              worked with the Boston Public Library, Cambridge Community
+              Television, and Northeast Historic Film to digitize and bring to
+              life local news stories produced in and about Boston from 1960 to
+              2000. Nearly 2,000 news programs are available online at
+              BostonLocalTV.org.
             </p>
 
             <p className="static-section">
-              The entire GBH collection and AAPB are available for research on location at GBH. Contact us to schedule a research visit in our Brighton, MA offices.
+              The entire GBH collection and AAPB are available for research on
+              location at GBH. Contact us to schedule a research visit in our
+              Brighton, MA offices.
             </p>
 
             <h2>Current Initiatives</h2>
 
             <p className="static-section">
-              In 2018, GBH received a $750,000 challenge grant from the National Endowment for the Humanities (NEH) to preserve and digitize the most at-risk items in the GBH archival collection, specifically 83,000 media resources. This effort will preserve the archive we have built and ensure that future media assets are properly preserved as they are created. The grant calls for a 4:1 match, or $3 million in matching dollars over the next four years.
+              In 2018, GBH received a $750,000 challenge grant from the National
+              Endowment for the Humanities (NEH) to preserve and digitize the
+              most at-risk items in the GBH archival collection, specifically
+              83,000 media resources. This effort will preserve the archive we
+              have built and ensure that future media assets are properly
+              preserved as they are created. The grant calls for a 4:1 match, or
+              $3 million in matching dollars over the next four years.
             </p>
 
             <p className="static-section">
-              A gift in support of Open Vault, leveraged by the NEH Challenge grant currently underway, directly enables us to:
+              A gift in support of Open Vault, leveraged by the NEH Challenge
+              grant currently underway, directly enables us to:
             </p>
 
             <ul>
-              <li>Digitize critical programs that are currently deteriorating on obsolete formats</li>
+              <li>
+                Digitize critical programs that are currently deteriorating on
+                obsolete formats
+              </li>
               <li>Add newly digitized content to Open Vault</li>
-              <li>Improve our website with new features and improve functionality and discoverability of the collection </li>
-              <li>Sustain Open Vault technical infrastructure so that we can continue to provide online access to the collection</li>
+              <li>
+                Improve our website with new features and improve functionality
+                and discoverability of the collection{' '}
+              </li>
+              <li>
+                Sustain Open Vault technical infrastructure so that we can
+                continue to provide online access to the collection
+              </li>
             </ul>
 
             <h2>Mailing Address</h2>
             <p className="static-section">
-              Open Vault<br /> GBH Archives<br /> WGBH Educational Foundation<br /> One Guest Street<br /> Boston, MA 02135
+              Open Vault
+              <br /> GBH Archives
+              <br /> WGBH Educational Foundation
+              <br /> One Guest Street
+              <br /> Boston, MA 02135
             </p>
-
           </div>
         </div>
       </div>

--- a/app/routes/collections._index.jsx
+++ b/app/routes/collections._index.jsx
@@ -1,6 +1,7 @@
-import { Link, useLoaderData } from '@remix-run/react'
+import { useLoaderData } from '@remix-run/react'
 import { getCollections } from '../fetch'
 import { renderPageLinks } from '../classes/pageHelpers'
+import { Meta } from '../classes/meta'
 
 export const loader = async () => {
   return await getCollections()
@@ -8,13 +9,12 @@ export const loader = async () => {
 
 export const meta = () => {
   return [
-    {
-      title: `Collections | GBH Open Vault`,
-    },
+    { title: 'Collections | GBH Open Vault' },
     {
       name: 'description',
-      content: `Explore Special Collections, curated from the GBH Archives.`,
+      content: 'Explore Special Collections, curated from the GBH Archives.',
     },
+    ...Meta,
   ]
 }
 

--- a/app/routes/credits.jsx
+++ b/app/routes/credits.jsx
@@ -1,4 +1,5 @@
-import { renderPageTitleBar } from "../classes/pageHelpers"
+import { renderPageTitleBar } from '../classes/pageHelpers'
+import { Meta } from '../classes/meta'
 
 export const meta = () => {
   return [
@@ -9,43 +10,73 @@ export const meta = () => {
       name: 'description',
       content: `Funders and credits for the GBH Open Vault project.`,
     },
+    ...Meta,
   ]
 }
 
 export default function Credits() {
-  let titleBar = renderPageTitleBar("Funders & Credits", "https://s3.amazonaws.com/openvault.wgbh.org/carousel/2mobile3.jpg")
+  let titleBar = renderPageTitleBar(
+    'Funders & Credits',
+    'https://s3.amazonaws.com/openvault.wgbh.org/carousel/2mobile3.jpg'
+  )
   return (
     <div>
       <div className="page-container">
-        { titleBar }
+        {titleBar}
 
         <div className="page-sidebar" />
 
         <div className="page-body-container">
           <div className="page-body">
-
             <h2>Digital Infrastructure Project</h2>
 
             <div className="med-textline">
-              The Digital Infrastructure Project has been made possible in part by a major grant from the National Endowment for the Humanities: Democracy demands wisdom. The National Endowment for the Humanities (NEH) issued a challenge grant to GBH Media Library and Archives in 2018 in support of the Digital Infrastructure Project to preserve and digitize the most at-risk items in the GBH archival collection, specifically 83,000 media resources. This effort will preserve the archive we have built and ensure that future media assets are properly preserved as they are created.
+              The Digital Infrastructure Project has been made possible in part
+              by a major grant from the National Endowment for the Humanities:
+              Democracy demands wisdom. The National Endowment for the
+              Humanities (NEH) issued a challenge grant to GBH Media Library and
+              Archives in 2018 in support of the Digital Infrastructure Project
+              to preserve and digitize the most at-risk items in the GBH
+              archival collection, specifically 83,000 media resources. This
+              effort will preserve the archive we have built and ensure that
+              future media assets are properly preserved as they are created.
             </div>
 
-            <div className="med-heading">Major funding for the Digital Infrastructure Project is provided by:</div>
+            <div className="med-heading">
+              Major funding for the Digital Infrastructure Project is provided
+              by:
+            </div>
             <div className="med-textline">
-              Linda and Andrew Egendorf | Barbara and Amos Hostetter | Charles and Lucille King Family Foundation Inc. | Lia and William Poorvu | Ruettgers Family Charitable Foundation
+              Linda and Andrew Egendorf | Barbara and Amos Hostetter | Charles
+              and Lucille King Family Foundation Inc. | Lia and William Poorvu |
+              Ruettgers Family Charitable Foundation
             </div>
 
-            <div className="med-heading">Additional funding for the Digital Infrastructure Project is provided by:</div>
-            <div className="med-textline">
-              Steve Duckworth | Richard Ferrante | Fliesbach Family Foundation | Gandrud Foundation | Ann and Graham Gund | Rosemarie Torres Johnson | Sara Lawrence-Lightfoot | Brian A. McCarthy Foundation | Slocumb and E. Lee Perry | Myrna Putziger | Henry M. Rines | Candis J. Stern Foundation
+            <div className="med-heading">
+              Additional funding for the Digital Infrastructure Project is
+              provided by:
             </div>
-            
+            <div className="med-textline">
+              Steve Duckworth | Richard Ferrante | Fliesbach Family Foundation |
+              Gandrud Foundation | Ann and Graham Gund | Rosemarie Torres
+              Johnson | Sara Lawrence-Lightfoot | Brian A. McCarthy Foundation |
+              Slocumb and E. Lee Perry | Myrna Putziger | Henry M. Rines |
+              Candis J. Stern Foundation
+            </div>
+
             <h2>Creating Open Vault</h2>
-            
+
             <div className="static-halfbox small-text">
               <div className="med-textline">
-                The initial creation of Open Vault was made possible in part by the <b>Institute of Museum and Library Services (IMLS)</b> (IMLS Grant Log Number LG-05-05-0220-05). IMLS further funded the development of Open Vault in 2008 by supporting the Vietnam Collection. The views, findings, conclusions or recommendations expressed in this website do not necessarily represent those of the Institute of Museum and Library Services. IMLS further funded the development of Open Vault in 2008 by supporting the Vietnam Collection. 
-
+                The initial creation of Open Vault was made possible in part by
+                the <b>Institute of Museum and Library Services (IMLS)</b> (IMLS
+                Grant Log Number LG-05-05-0220-05). IMLS further funded the
+                development of Open Vault in 2008 by supporting the Vietnam
+                Collection. The views, findings, conclusions or recommendations
+                expressed in this website do not necessarily represent those of
+                the Institute of Museum and Library Services. IMLS further
+                funded the development of Open Vault in 2008 by supporting the
+                Vietnam Collection.
               </div>
             </div>
             <div className="static-halfbox small-text spaced org-logos">
@@ -54,7 +85,8 @@ export default function Credits() {
 
             <div className="static-halfbox small-text">
               <div className="med-textline">
-                The prototype website was funded in part by <b>The John D. and Catherine T. MacArthur Foundation</b>. 
+                The prototype website was funded in part by{' '}
+                <b>The John D. and Catherine T. MacArthur Foundation</b>.
               </div>
             </div>
             <div className="static-halfbox small-text spaced org-logos">
@@ -63,7 +95,13 @@ export default function Credits() {
 
             <div className="static-halfbox small-text">
               <div className="med-textline">
-                The <b>Andrew W. Mellon Foundation</b> supported the further development of Open Vault through the Digital Library Initiative, funding the addition of new functionality and features such as a catalog, scholar exhibits, and digitization on demand. This site brings together materials from three previous web sites: New Television Workshop, Say Brother, Ten O’Clock News
+                The <b>Andrew W. Mellon Foundation</b> supported the further
+                development of Open Vault through the Digital Library
+                Initiative, funding the addition of new functionality and
+                features such as a catalog, scholar exhibits, and digitization
+                on demand. This site brings together materials from three
+                previous web sites: New Television Workshop, Say Brother, Ten
+                O’Clock News
               </div>
             </div>
             <div className="static-halfbox small-text spaced org-logos">
@@ -72,13 +110,13 @@ export default function Credits() {
 
             <h2>Open Vault Credits</h2>
 
-            <div className="static-halfbox small-text spaced static-credits"> 
+            <div className="static-halfbox small-text spaced static-credits">
               <div>
                 <div className="gray spaced">Project Management</div>
                 <div className="black">Karen Cariani, Project Director</div>
                 <div className="black">Karen Colbron, Project Manager</div>
               </div>
-              
+
               <div>
                 <div className="gray spaced">Business Manager</div>
                 <div className="black">Paul Plutnicki</div>
@@ -101,21 +139,28 @@ export default function Credits() {
                 <div className="gray spaced">Copyeditor</div>
                 <div className="black">Eleanor Beram</div>
               </div>
-
             </div>
             <div className="static-halfbox small-text spaced static-credits">
               <div>
                 <div className="gray spaced">With thanks to</div>
-                <div className="black">Steve Baldwin, National Boston Ned Biddle, National Boston Kevin Carter, technical advisor, GBH Nancy Dillon, library manager, GBH Dale Freeman, assistant archivist, Archives and Special Collections Department, Healey Library, University of Massachusetts at Boston</div>
+                <div className="black">
+                  Steve Baldwin, National Boston Ned Biddle, National Boston
+                  Kevin Carter, technical advisor, GBH Nancy Dillon, library
+                  manager, GBH Dale Freeman, assistant archivist, Archives and
+                  Special Collections Department, Healey Library, University of
+                  Massachusetts at Boston
+                </div>
               </div>
 
               <div>
-                <div className="gray spaced">Special thanks to our friends and colleagues in Archives:</div>
-                <div className="black">Jordan Berson, Mary Ide, Keith Luf, Jonathan Pipe, Leah Weisse</div>
+                <div className="gray spaced">
+                  Special thanks to our friends and colleagues in Archives:
+                </div>
+                <div className="black">
+                  Jordan Berson, Mary Ide, Keith Luf, Jonathan Pipe, Leah Weisse
+                </div>
               </div>
-
             </div>
-
           </div>
         </div>
       </div>

--- a/app/routes/exhibits.$exhibitSlug.tsx
+++ b/app/routes/exhibits.$exhibitSlug.tsx
@@ -3,32 +3,58 @@ import {
   useRouteError,
   isRouteErrorResponse,
 } from '@remix-run/react'
+import type { LoaderFunction, MetaFunction } from '@remix-run/node'
+import { json } from '@remix-run/node'
 import { getPageBySlug } from '../fetch'
 import { renderExhibit } from '../classes/exhibitPresenter'
 import type { SitemapFunction } from 'remix-sitemap'
 
-export const loader = async ({ params }) => {
-  console.log('exx path ', params)
+export const loader: LoaderFunction = async ({ params, request }) => {
+  let server_url = request.url
+  // console.log('exx path ', params)
   let exhibit = await getPageBySlug('exhibits', params.exhibitSlug)
-  console.log('exhibit loader', exhibit)
-  return exhibit
+  // console.log('exhibit loader', exhibit)
+  return json({exhibit, server_url})
 }
 
-export const meta = ({ data }) => {
+export const meta: MetaFunction = ({ data, location }) => {
+  // console.log('exhibit meta', data)
+  let exhibit = data.exhibit
   return [
     {
-      title: `${data.title} | GBH Open Vault`,
+      title: `${exhibit.title} | GBH Open Vault`,
     },
     {
       name: 'description',
-      content: data.meta.search_description || 'GBH Open Vault Exhibit',
+      content: exhibit.meta.search_description || 'GBH Open Vault Exhibit',
     },
+    {
+      name: 'og:url',
+      content: data.server_url,
+    },
+    {
+      name: 'og:type',
+      content: 'article',
+    },
+    {
+      name: 'og:title',
+      content: exhibit.title,
+    },
+    {
+      name: 'og:description',
+      content: exhibit.meta.search_description || 'GBH Open Vault Exhibit',
+    },
+    {
+      name: 'og:image',
+      content: exhibit.cover_image.url,
+    },
+
   ]
 }
 
 export default function Exhibit() {
-  const exhibit = useLoaderData()
-  console.log('exhibit', exhibit)
+  const {exhibit} = useLoaderData()
+  // console.log('exhibit', exhibit)
 
   return renderExhibit(exhibit)
 }

--- a/app/routes/exhibits.$exhibitSlug.tsx
+++ b/app/routes/exhibits.$exhibitSlug.tsx
@@ -3,57 +3,45 @@ import {
   useRouteError,
   isRouteErrorResponse,
 } from '@remix-run/react'
-import type { LoaderFunction, MetaFunction } from '@remix-run/node'
+import type {
+  LoaderFunction,
+  MetaFunction,
+  LoaderFunctionArgs,
+} from '@remix-run/node'
 import { json } from '@remix-run/node'
 import { getPageBySlug } from '../fetch'
 import { renderExhibit } from '../classes/exhibitPresenter'
 import type { SitemapFunction } from 'remix-sitemap'
+import { extractMeta } from '../classes/meta'
 
-export const loader: LoaderFunction = async ({ params, request }) => {
+export const loader: LoaderFunction = async ({
+  params,
+  request,
+}: LoaderFunctionArgs) => {
   let server_url = request.url
   // console.log('exx path ', params)
   let exhibit = await getPageBySlug('exhibits', params.exhibitSlug)
   // console.log('exhibit loader', exhibit)
-  return json({exhibit, server_url})
+  return json({ exhibit, server_url })
 }
 
-export const meta: MetaFunction = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
   // console.log('exhibit meta', data)
   let exhibit = data.exhibit
   return [
-    {
-      title: `${exhibit.title} | GBH Open Vault`,
-    },
+    { title: `${exhibit.title} | GBH Open Vault` },
     {
       name: 'description',
-      content: exhibit.meta.search_description || 'GBH Open Vault Exhibit',
+      content:
+        exhibit.meta.search_description ||
+        'Scholar Exhibit from GBH Open Vault',
     },
-    {
-      name: 'og:url',
-      content: data.server_url,
-    },
-    {
-      name: 'og:type',
-      content: 'article',
-    },
-    {
-      name: 'og:title',
-      content: exhibit.title,
-    },
-    {
-      name: 'og:description',
-      content: exhibit.meta.search_description || 'GBH Open Vault Exhibit',
-    },
-    {
-      name: 'og:image',
-      content: exhibit.cover_image.url,
-    },
-
+    ...extractMeta(data.server_url, exhibit),
   ]
 }
 
 export default function Exhibit() {
-  const {exhibit} = useLoaderData()
+  const { exhibit } = useLoaderData()
   // console.log('exhibit', exhibit)
 
   return renderExhibit(exhibit)

--- a/app/routes/exhibits._index.jsx
+++ b/app/routes/exhibits._index.jsx
@@ -1,6 +1,7 @@
 import { Link, useLoaderData } from '@remix-run/react'
 import { getExhibits } from '../fetch'
 import { renderPageLinks } from '../classes/pageHelpers'
+import { Meta } from '../classes/meta'
 
 export const loader = async () => {
   return await getExhibits()
@@ -8,13 +9,12 @@ export const loader = async () => {
 
 export const meta = () => {
   return [
-    {
-      title: `Scholar Exhibits | GBH Open Vault`,
-    },
+    { title: `Scholar Exhibits | GBH Open Vault` },
     {
       name: 'description',
       content: `Explore exhibits created by scholars from the GBH Archives.`,
     },
+    ...Meta,
   ]
 }
 

--- a/app/routes/faq.jsx
+++ b/app/routes/faq.jsx
@@ -1,4 +1,4 @@
-import { renderPageTitleBar } from "../classes/pageHelpers"
+import { Meta } from '../classes/meta'
 
 export const meta = () => {
   return [
@@ -9,6 +9,7 @@ export const meta = () => {
       name: 'description',
       content: `Frequently Asked Questions about GBH Open Vault.`,
     },
+    ...Meta,
   ]
 }
 
@@ -16,41 +17,69 @@ export default function FAQ() {
   return (
     <div>
       <div className="page-container">
-
         <div className="page-sidebar" />
 
         <div className="page-body-container">
-
           <div className="page-body">
             <h2>Frequently Asked Questions</h2>
-            <div className="med-heading">I can't get one of the video or audio records to play. What should I do?</div>
+            <div className="med-heading">
+              I can't get one of the video or audio records to play. What should
+              I do?
+            </div>
             <div className="med-textline">
-              Please make sure your web browser is updated to the latest version. If the record still will not play, please <a href="/contact-us">contact us</a>.
+              Please make sure your web browser is updated to the latest
+              version. If the record still will not play, please{' '}
+              <a href="/contact-us">contact us</a>.
             </div>
 
-            <div className="med-heading">I have found a factual error in one of the records. Who should I contact?</div>
+            <div className="med-heading">
+              I have found a factual error in one of the records. Who should I
+              contact?
+            </div>
             <div className="med-textline">
               <a href="/contact-us">Contact us here.</a>
             </div>
 
-            <div className="med-heading">Can I buy copies of the programs on Open Vault?</div>
-            <div className="med-textline">
-              Most programs are no longer available for distribution. Please refer to <a href="https://shop.pbs.org/">shop.pbs.org</a> for the latest catalog of programs available for distribution.
+            <div className="med-heading">
+              Can I buy copies of the programs on Open Vault?
             </div>
-            
-            <div className="med-heading">Can I buy copies of source materials (interviews, news footage, b-roll, etc)?</div>
             <div className="med-textline">
-              For professional licensing requests, please contact GBH Stock Sales at 617-300-3939 or <a href="mailto:stock_sales@wgbh.org?subject=Open%20Vault%20licensing">stock_sales@wgbh.org</a>.
-            </div>
-
-            <div className="med-heading">How can I arrange to visit the GBH Archives?</div>
-            <div className="med-textline">
-              Individuals wishing to visit the Archives should be engaged in educational research. Please see <a href="/visit-us">Visit Us</a> for further information.
+              Most programs are no longer available for distribution. Please
+              refer to <a href="https://shop.pbs.org/">shop.pbs.org</a> for the
+              latest catalog of programs available for distribution.
             </div>
 
-            <div className="med-heading">Can you provide me with contact information for any of the people in the clips?</div>
+            <div className="med-heading">
+              Can I buy copies of source materials (interviews, news footage,
+              b-roll, etc)?
+            </div>
             <div className="med-textline">
-              WGBH Educational Foundation cannot provide the names, addresses, telephone numbers, or e-mail addresses of individuals, next of kin, estates, or related organizations for people who appeared in GBH programs. To do so would violate GBH's Privacy Policy.
+              For professional licensing requests, please contact GBH Stock
+              Sales at 617-300-3939 or{' '}
+              <a href="mailto:stock_sales@wgbh.org?subject=Open%20Vault%20licensing">
+                stock_sales@wgbh.org
+              </a>
+              .
+            </div>
+
+            <div className="med-heading">
+              How can I arrange to visit the GBH Archives?
+            </div>
+            <div className="med-textline">
+              Individuals wishing to visit the Archives should be engaged in
+              educational research. Please see <a href="/visit-us">Visit Us</a>{' '}
+              for further information.
+            </div>
+
+            <div className="med-heading">
+              Can you provide me with contact information for any of the people
+              in the clips?
+            </div>
+            <div className="med-textline">
+              WGBH Educational Foundation cannot provide the names, addresses,
+              telephone numbers, or e-mail addresses of individuals, next of
+              kin, estates, or related organizations for people who appeared in
+              GBH programs. To do so would violate GBH's Privacy Policy.
             </div>
           </div>
         </div>

--- a/app/routes/privacy-policy.jsx
+++ b/app/routes/privacy-policy.jsx
@@ -1,4 +1,5 @@
-import { renderPageTitleBar } from "../classes/pageHelpers"
+import { renderPageTitleBar } from '../classes/pageHelpers'
+import { Meta } from '../classes/meta'
 
 export const meta = () => {
   return [
@@ -9,98 +10,309 @@ export const meta = () => {
       name: 'description',
       content: `Privacy Policy for GBH Open Vault.`,
     },
+    ...Meta,
   ]
 }
 
 export default function Terms() {
-  let titleBar = renderPageTitleBar("Terms And Conditions", "https://s3.amazonaws.com/openvault.wgbh.org/carousel/Camera+Frog+Pond+early.jpg")
+  let titleBar = renderPageTitleBar(
+    'Terms And Conditions',
+    'https://s3.amazonaws.com/openvault.wgbh.org/carousel/Camera+Frog+Pond+early.jpg'
+  )
 
   return (
     <div>
       <div className="page-container">
-        { titleBar }
+        {titleBar}
 
         <div className="page-sidebar" />
 
         <div className="page-body-container">
           <div className="page-body">
             <h2>Privacy Policy</h2>
-            <p>Thank you for visiting openvault.wgbh.org. Open Vault provides educational resources for teachers and students for individual and classroom opportunities for study. The Privacy Policy set forth here refers solely to the Open Vault website.</p>
-
-            <p>We know you don’t want the information you provide us shared indiscriminately. Here we explain what information GBH and our third-party vendors (collectively “we”) acting on our behalf to help deliver the services and operate and analyze use of the Site collect, what we do with the information, and what controls you have over the information collected. We’re committed to ensuring the privacy of your personally identifiable information, and to protecting your ability to make financial transactions and transmit your personal data with full confidence.</p>
-
-            <p>The privacy policy set forth here refers solely to openvault.wgbh.org. Please read it carefully, and if you have any questions or concerns, please contact us. Also, note that openvault.wgbh.org links to numerous other sites, such as GBH, PBS, and the University of Massachusetts at Amherst. Please consult those sites to learn more about their policies.</p>
-
+            <p>
+              Thank you for visiting openvault.wgbh.org. Open Vault provides
+              educational resources for teachers and students for individual and
+              classroom opportunities for study. The Privacy Policy set forth
+              here refers solely to the Open Vault website.
+            </p>
+            <p>
+              We know you don’t want the information you provide us shared
+              indiscriminately. Here we explain what information GBH and our
+              third-party vendors (collectively “we”) acting on our behalf to
+              help deliver the services and operate and analyze use of the Site
+              collect, what we do with the information, and what controls you
+              have over the information collected. We’re committed to ensuring
+              the privacy of your personally identifiable information, and to
+              protecting your ability to make financial transactions and
+              transmit your personal data with full confidence.
+            </p>
+            <p>
+              The privacy policy set forth here refers solely to
+              openvault.wgbh.org. Please read it carefully, and if you have any
+              questions or concerns, please contact us. Also, note that
+              openvault.wgbh.org links to numerous other sites, such as GBH,
+              PBS, and the University of Massachusetts at Amherst. Please
+              consult those sites to learn more about their policies.
+            </p>
             <h3>1. WHAT INFORMATION DO WE COLLECT ABOUT YOU?</h3>
-            <p>We collect two types of information from you: a) Personally identifiable information, which includes personal information (such as your name, address, e-mail address, telephone number, credit card information and/or other identifying information) you voluntarily supply upon request when you register for our website, make a donation, complete a survey, register for an online discussion, enter a contest, or provide your e-mail address; and b) Non-personally identifiable information, for example IP Addresses and cookies, which include tracking information collected as you navigate through our site. Uses of this information are discussed in Section 2 below.</p>
-
+            <p>
+              We collect two types of information from you: a) Personally
+              identifiable information, which includes personal information
+              (such as your name, address, e-mail address, telephone number,
+              credit card information and/or other identifying information) you
+              voluntarily supply upon request when you register for our website,
+              make a donation, complete a survey, register for an online
+              discussion, enter a contest, or provide your e-mail address; and
+              b) Non-personally identifiable information, for example IP
+              Addresses and cookies, which include tracking information
+              collected as you navigate through our site. Uses of this
+              information are discussed in Section 2 below.
+            </p>
             <p>A. Personally Identifiable Information</p>
-            We will not collect personally identifiable information from you, other than what you supply to us on a voluntary basis upon request.
-
+            We will not collect personally identifiable information from you,
+            other than what you supply to us on a voluntary basis upon request.
             <p>Registration for our website:</p>
-            Anyone can view our site, however some pages of the Site may require a free registration which enables full access to the information and resources offered throughout the Site. A unique email address (user name) and password must be supplied to register. By using the Site, you are agreeing to the conditions of our Terms of Use.
-
+            Anyone can view our site, however some pages of the Site may require
+            a free registration which enables full access to the information and
+            resources offered throughout the Site. A unique email address (user
+            name) and password must be supplied to register. By using the Site,
+            you are agreeing to the conditions of our Terms of Use.
             <p>Support of Open Vault and the GBH Archives:</p>
-            On certain pages within the Site we may now or in the future offer visitors the opportunity to make a donation in support ofthe Open Vault website and the GBH Archives. If a visitor chooses to make a donation, we will collect and store your telephone number, e-mail address, billing address and credit card information.
-
+            On certain pages within the Site we may now or in the future offer
+            visitors the opportunity to make a donation in support ofthe Open
+            Vault website and the GBH Archives. If a visitor chooses to make a
+            donation, we will collect and store your telephone number, e-mail
+            address, billing address and credit card information.
             <p>Content Submissions:</p>
-            On certain pages within the Site you can submit content to be published, such as tags, annotations, and comments. We may collect your name, address, and e-mail addresses in connection with these activities. We will indicate which information is required and which is optional. We may contact users regarding their submissions in certain circumstances.
-
-            <p>Your submission of others’ Personally Identifiable Information:</p>
-            On certain pages within the Site you can submit information about other people. For example, you may submit a person’s name and email address to send an article. This information will only be used for your intended purpose.
-
+            On certain pages within the Site you can submit content to be
+            published, such as tags, annotations, and comments. We may collect
+            your name, address, and e-mail addresses in connection with these
+            activities. We will indicate which information is required and which
+            is optional. We may contact users regarding their submissions in
+            certain circumstances.
+            <p>
+              Your submission of others’ Personally Identifiable Information:
+            </p>
+            On certain pages within the Site you can submit information about
+            other people. For example, you may submit a person’s name and email
+            address to send an article. This information will only be used for
+            your intended purpose.
             <p>E-Mail and E-Mail Newsletters:</p>
-            On occasion, we may collect personal information from users in connection with optional emails and e-mail newsletters. We will indicate which information is required and which is optional. Such information will be used as indicated at the time of collection.
-
+            On occasion, we may collect personal information from users in
+            connection with optional emails and e-mail newsletters. We will
+            indicate which information is required and which is optional. Such
+            information will be used as indicated at the time of collection.
             <p>Marketing and Promotional Communications:</p>
-            On occasion, we may collect personal information from users in connection with optional marketing and promotional communications from GBH, PBS, or a public broadcasting station. We will indicate which information is required and which is optional. Such information will be used as indicated at the time of collection.
-
+            On occasion, we may collect personal information from users in
+            connection with optional marketing and promotional communications
+            from GBH, PBS, or a public broadcasting station. We will indicate
+            which information is required and which is optional. Such
+            information will be used as indicated at the time of collection.
             <p>B. Non-personally Identifiable Information</p>
-            In addition to information that you provide to us, we (again, this is GBH and our affiliates and third party vendors) may also collect and store certain non-personally identifiable information automatically when you use the Site. This information helps us improve the experience you and other visitors have with the Site.
-
-            <p>For example, we may collect your IP address, browser information and reference site domain, as well as related information such as the date on which you visit the Site. This information does not identify you personally and is only used in the aggregate.</p>
-
-            <p>As is common practice among web sites, we use “cookies” and similar technologies. In general, cookies — the informational files that your web browser places on your computer when you visit a website — are used on this Site to track and analyze how you and other visitors use our Site. We use these cookies in order to improve the Site, to identify the source of visitors and what pages you use while on our site, to offer visitors interactive and/or personalized features that would not be possible without the cookies, to recall specific information to save visitors time when they return to the Site, to provide our sponsors targeted sponsorship opportunities, to provide visitors customized sponsorship messages or list of customized videos of interest, and to identify usage and statistical trends. By looking at this traffic we can better understand our community, which allows us to improve our Site and to provide you with an optimal experience and better service. Our sponsorship service vendors, which serve sponsorship messages onto our site, and third party vendors that measure and analyze the use of the Site for us, may also use their own cookies. At no time does the cookie reveal your name, address, or e-mail address (even if you have entered these in specific areas of the Site). The Site pages cannot extract any personally identifying information about you from what we receive via a cookie and your browser.</p>
-
-            <p>You can set your browser preferences to refuse cookies or to alert you when cookies are being sent. However, some parts of the Site will not function properly if you do so.</p>
-
+            In addition to information that you provide to us, we (again, this
+            is GBH and our affiliates and third party vendors) may also collect
+            and store certain non-personally identifiable information
+            automatically when you use the Site. This information helps us
+            improve the experience you and other visitors have with the Site.
+            <p>
+              For example, we may collect your IP address, browser information
+              and reference site domain, as well as related information such as
+              the date on which you visit the Site. This information does not
+              identify you personally and is only used in the aggregate.
+            </p>
+            <p>
+              As is common practice among web sites, we use “cookies” and
+              similar technologies. In general, cookies — the informational
+              files that your web browser places on your computer when you visit
+              a website — are used on this Site to track and analyze how you and
+              other visitors use our Site. We use these cookies in order to
+              improve the Site, to identify the source of visitors and what
+              pages you use while on our site, to offer visitors interactive
+              and/or personalized features that would not be possible without
+              the cookies, to recall specific information to save visitors time
+              when they return to the Site, to provide our sponsors targeted
+              sponsorship opportunities, to provide visitors customized
+              sponsorship messages or list of customized videos of interest, and
+              to identify usage and statistical trends. By looking at this
+              traffic we can better understand our community, which allows us to
+              improve our Site and to provide you with an optimal experience and
+              better service. Our sponsorship service vendors, which serve
+              sponsorship messages onto our site, and third party vendors that
+              measure and analyze the use of the Site for us, may also use their
+              own cookies. At no time does the cookie reveal your name, address,
+              or e-mail address (even if you have entered these in specific
+              areas of the Site). The Site pages cannot extract any personally
+              identifying information about you from what we receive via a
+              cookie and your browser.
+            </p>
+            <p>
+              You can set your browser preferences to refuse cookies or to alert
+              you when cookies are being sent. However, some parts of the Site
+              will not function properly if you do so.
+            </p>
             <h3>2. HOW DO WE USE INFORMATION GATHERED ON THE SITE?</h3>
-            <p>Neither GBH, nor our third-party vendors acting on our behalf to help deliver the services and operate the Site, will willfully disclose any personally identifiable information about our online users to any non-affiliated third party without first receiving the user’s permission, unless required by law. GBH’s affiliates include our local and national productions (for example, NOVA, and Forum Network), PBS, and other public broadcasting stations or programming.</p>
-
-            <p>In terms of our own use of information, we may use your personally identifiable information for the activities described in the previous sections, for the activities described when you submitted the information, or for internal and marketing promotional purposes as further described in this policy.</p>
-
-            <p>We will typically explain the extent of use at the time you are asked to provide personal information. If you do not want this information to be collected or used by us for these purposes, you can simply “opt out.” Under certain circumstances, opting out may prevent your participation in activities for which personal information is needed, as in contests.</p>
-
-            <p>As mentioned, in certain cases, we contract with other companies to provide services on our behalf. These service providers maintain customer databases with e-mail addresses of Site visitors who have provided them to us by registering at our site, signing up for a newsletter or listserv, e-mailing us questions about the service, donors who submit online contributions, or online buyers who make a purchase. We (which includes our service providers) will use these addresses to respond to the general purposes for which we collected the information, to provide services and to operate the Site, including to respond to inquiries; to process credit card payments, billing, and shipping; to process e-mail distribution; for list processing and analysis; for promotions management; to send information about GBH’s programs, services, or your local public broadcasting station’s membership/fundraising; or to correspond about a purchase or product offers. Our service providers have access to your personally identifiable information as necessary to provide certain services on our behalf. They are required to maintain the privacy of all such information in their possession or control and can only use the information on our behalf for the purpose that we have contracted them, for example sending you a newsletter. They are not authorized to use your information for any other purpose.</p>
-
-            <p>Similarly, personally identifiable information provided in connection with a donation will be shared with third parties who perform services to process the donation.</p>
-
-            <p>We will not sell, exchange, or lend e-mail addresses to any non-affiliated third party without your permission. However, we or our service providers may release personally identifiable information if we believe in good faith that the law or legal process requires it, we have received a valid administrative request from a law enforcement agency, or such release is necessary to protect anyone’s rights, property or safety.</p>
-
-            <p>On certain pages, we may now or in the future, offer visitors the opportunity to provide comments, messages or other user-generated text, content or materials (collectively “User Materials”). Any information that you disclose when posting a message to these areas, such as your name, screen name or ID used, becomes public. In addition, the information that you disclose in these areas may be used by us for promotional and marketing purposes. We are not responsible for any personally identifiable information that you choose to disclose in these public areas. Further, GBH, its production units, public broadcasting station affiliates and their licensees, may use, copy, sublicense, modify, transmit, publicly perform, display, create derivative works of, host, index, cache, tag, encode, and/or adapt any User Materials, and any information contained therein, in any and all media formats or channels, whether now known or hereafter devised, including, but not limited to, the Site, public broadcasting station web sites, other third party web sites, over the air (on radio or television), and on mobile platforms.</p>
-
-            <p>We reserve the right to send you e-mail relating to your account status. This includes order confirmations, renewal/expiration notices, notices of credit-card problems, other transactional e-mails and notifications about major changes to our Site and/or to our Privacy Policy.</p>
-
-            <p>GBH, with the assistance from time to time of its third party service vendors, uses non-identifying aggregate information to analyze use of and better design the Site and to share with third parties in aggregate form only as appropriate. For example, we may tell a third party that a certain number of users accessed a particular video on our Site. However, we will not disclose any information that could be used to identify those users.</p>
-
+            <p>
+              Neither GBH, nor our third-party vendors acting on our behalf to
+              help deliver the services and operate the Site, will willfully
+              disclose any personally identifiable information about our online
+              users to any non-affiliated third party without first receiving
+              the user’s permission, unless required by law. GBH’s affiliates
+              include our local and national productions (for example, NOVA, and
+              Forum Network), PBS, and other public broadcasting stations or
+              programming.
+            </p>
+            <p>
+              In terms of our own use of information, we may use your personally
+              identifiable information for the activities described in the
+              previous sections, for the activities described when you submitted
+              the information, or for internal and marketing promotional
+              purposes as further described in this policy.
+            </p>
+            <p>
+              We will typically explain the extent of use at the time you are
+              asked to provide personal information. If you do not want this
+              information to be collected or used by us for these purposes, you
+              can simply “opt out.” Under certain circumstances, opting out may
+              prevent your participation in activities for which personal
+              information is needed, as in contests.
+            </p>
+            <p>
+              As mentioned, in certain cases, we contract with other companies
+              to provide services on our behalf. These service providers
+              maintain customer databases with e-mail addresses of Site visitors
+              who have provided them to us by registering at our site, signing
+              up for a newsletter or listserv, e-mailing us questions about the
+              service, donors who submit online contributions, or online buyers
+              who make a purchase. We (which includes our service providers)
+              will use these addresses to respond to the general purposes for
+              which we collected the information, to provide services and to
+              operate the Site, including to respond to inquiries; to process
+              credit card payments, billing, and shipping; to process e-mail
+              distribution; for list processing and analysis; for promotions
+              management; to send information about GBH’s programs, services, or
+              your local public broadcasting station’s membership/fundraising;
+              or to correspond about a purchase or product offers. Our service
+              providers have access to your personally identifiable information
+              as necessary to provide certain services on our behalf. They are
+              required to maintain the privacy of all such information in their
+              possession or control and can only use the information on our
+              behalf for the purpose that we have contracted them, for example
+              sending you a newsletter. They are not authorized to use your
+              information for any other purpose.
+            </p>
+            <p>
+              Similarly, personally identifiable information provided in
+              connection with a donation will be shared with third parties who
+              perform services to process the donation.
+            </p>
+            <p>
+              We will not sell, exchange, or lend e-mail addresses to any
+              non-affiliated third party without your permission. However, we or
+              our service providers may release personally identifiable
+              information if we believe in good faith that the law or legal
+              process requires it, we have received a valid administrative
+              request from a law enforcement agency, or such release is
+              necessary to protect anyone’s rights, property or safety.
+            </p>
+            <p>
+              On certain pages, we may now or in the future, offer visitors the
+              opportunity to provide comments, messages or other user-generated
+              text, content or materials (collectively “User Materials”). Any
+              information that you disclose when posting a message to these
+              areas, such as your name, screen name or ID used, becomes public.
+              In addition, the information that you disclose in these areas may
+              be used by us for promotional and marketing purposes. We are not
+              responsible for any personally identifiable information that you
+              choose to disclose in these public areas. Further, GBH, its
+              production units, public broadcasting station affiliates and their
+              licensees, may use, copy, sublicense, modify, transmit, publicly
+              perform, display, create derivative works of, host, index, cache,
+              tag, encode, and/or adapt any User Materials, and any information
+              contained therein, in any and all media formats or channels,
+              whether now known or hereafter devised, including, but not limited
+              to, the Site, public broadcasting station web sites, other third
+              party web sites, over the air (on radio or television), and on
+              mobile platforms.
+            </p>
+            <p>
+              We reserve the right to send you e-mail relating to your account
+              status. This includes order confirmations, renewal/expiration
+              notices, notices of credit-card problems, other transactional
+              e-mails and notifications about major changes to our Site and/or
+              to our Privacy Policy.
+            </p>
+            <p>
+              GBH, with the assistance from time to time of its third party
+              service vendors, uses non-identifying aggregate information to
+              analyze use of and better design the Site and to share with third
+              parties in aggregate form only as appropriate. For example, we may
+              tell a third party that a certain number of users accessed a
+              particular video on our Site. However, we will not disclose any
+              information that could be used to identify those users.
+            </p>
             <h3>3. SECURITY OF INFORMATION</h3>
-            <p>GBH has in place what we believe to be appropriate physical, electronic, and managerial procedures to safeguard and secure the information we collect online. Credit card information provided on the Site is protected against unauthorized use by Secure Sockets Layer (SSL) security features. The SSL protocol is the industry standard method for creating an encrypted, secure connection between your web browser and a web server, such as the Site’s server. You should, however, keep in mind that no Internet or e-mail transmission is ever fully secure or error free. Because most e-mail is not encrypted, you should take special care in deciding what information you send to us via e-mail.</p>
-
+            <p>
+              GBH has in place what we believe to be appropriate physical,
+              electronic, and managerial procedures to safeguard and secure the
+              information we collect online. Credit card information provided on
+              the Site is protected against unauthorized use by Secure Sockets
+              Layer (SSL) security features. The SSL protocol is the industry
+              standard method for creating an encrypted, secure connection
+              between your web browser and a web server, such as the Site’s
+              server. You should, however, keep in mind that no Internet or
+              e-mail transmission is ever fully secure or error free. Because
+              most e-mail is not encrypted, you should take special care in
+              deciding what information you send to us via e-mail.
+            </p>
             <h3>4. CHILDREN’S GUIDELINES</h3>
-            <p>openvault.wgbh.org is a general audience site and does not knowingly collect or store personally identifiable information about children under the age of 13.</p>
-
+            <p>
+              openvault.wgbh.org is a general audience site and does not
+              knowingly collect or store personally identifiable information
+              about children under the age of 13.
+            </p>
             <h3>5. CORRECTIONS TO PERSONAL DATA; OPTING OUT</h3>
-            <p>Please Contact Us to a) correct or update any personal information in the GBH database that you state is erroneous, b) opt-out of future communications from GBH, or c) request GBH to make reasonable efforts to remove your personal information from the GBH online database, thereby canceling your profile, newsletter registration and other GBH registrations. This will not necessarily remove previous public comments and other User Materials submitted for public display on the Site. You should understand that it may be impossible to delete personal information entirely because of backups and records of deletions.</p>
-
+            <p>
+              Please Contact Us to a) correct or update any personal information
+              in the GBH database that you state is erroneous, b) opt-out of
+              future communications from GBH, or c) request GBH to make
+              reasonable efforts to remove your personal information from the
+              GBH online database, thereby canceling your profile, newsletter
+              registration and other GBH registrations. This will not
+              necessarily remove previous public comments and other User
+              Materials submitted for public display on the Site. You should
+              understand that it may be impossible to delete personal
+              information entirely because of backups and records of deletions.
+            </p>
             <h3>6. ACCEPTANCE OF THIS PRIVACY POLICY FOR OPENVAULT.WGBH.ORG</h3>
-            <p>By using this site, you signify your agreement to the terms and conditions of this Privacy Policy for openvault.wgbh.org. If you do not agree to these terms and conditions, please do not use this Site. We reserve the right, at our sole discretion, to change, modify, add, or remove portions of this policy at any time. Please check this page periodically for any changes. Your continued use of GBH.org following the posting of any changes to these terms shall mean that you have accepted those changes. If you have any questions or concerns, please contact us.</p>
-
+            <p>
+              By using this site, you signify your agreement to the terms and
+              conditions of this Privacy Policy for openvault.wgbh.org. If you
+              do not agree to these terms and conditions, please do not use this
+              Site. We reserve the right, at our sole discretion, to change,
+              modify, add, or remove portions of this policy at any time. Please
+              check this page periodically for any changes. Your continued use
+              of GBH.org following the posting of any changes to these terms
+              shall mean that you have accepted those changes. If you have any
+              questions or concerns, please contact us.
+            </p>
             <h3>7. CHANGES TO THIS PRIVACY POLICY</h3>
-            <p>Whenever this Privacy Policy for our Site changes, we will post the changes to the Site, and such changes will be effective immediately upon posting. If you do not agree to the changes, please do not continue to use the Site. Under certain circumstances, we may also elect to notify you of changes or updates to our Privacy Policy by additional means, such as posting a notice on the front page of our Site or sending you an e-mail if we have your e-mail address.</p>
-
+            <p>
+              Whenever this Privacy Policy for our Site changes, we will post
+              the changes to the Site, and such changes will be effective
+              immediately upon posting. If you do not agree to the changes,
+              please do not continue to use the Site. Under certain
+              circumstances, we may also elect to notify you of changes or
+              updates to our Privacy Policy by additional means, such as posting
+              a notice on the front page of our Site or sending you an e-mail if
+              we have your e-mail address.
+            </p>
             <h3>8. TERMS OF USE</h3>
-            <p>Please also make sure to read openvault.wgbh.org’s Terms of Use to understand the additional terms and conditions that apply to your use of our Site.</p>
-
+            <p>
+              Please also make sure to read openvault.wgbh.org’s Terms of Use to
+              understand the additional terms and conditions that apply to your
+              use of our Site.
+            </p>
           </div>
         </div>
       </div>

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -6,6 +6,7 @@ import { Panel } from '../components/Panel'
 import { Search } from '../classes/search-ui'
 import 'instantsearch.css/themes/algolia-min.css'
 import '../styles/search.css'
+import { Meta } from '../classes/meta'
 
 export const meta: MetaFunction = ({ location }) => {
   const query = new URLSearchParams(location.search).get('q')
@@ -18,6 +19,7 @@ export const meta: MetaFunction = ({ location }) => {
       content:
         'Search the GBH Open Vault catalog, Scholar Exhibits and Special Collections.',
     },
+    ...Meta,
   ]
 }
 
@@ -46,12 +48,7 @@ export type SearchProps = {
 
 export default function SearchPage() {
   const { serverUrl, aapb_host }: SearchProps = useLoaderData()
-  return (
-    <Search
-      serverUrl={serverUrl}
-      aapb_host={aapb_host}
-    />
-  )
+  return <Search serverUrl={serverUrl} aapb_host={aapb_host} />
 }
 
 export function ErrorBoundary() {

--- a/app/routes/series.jsx
+++ b/app/routes/series.jsx
@@ -1,10 +1,6 @@
 import { Component } from 'react'
 import { seriesData } from '../data/seriesData'
-
-// // commented out so we can use fake data
-// export const loader = async () => {
-//   return await getExhibits()
-// }
+import { Meta } from '../classes/meta'
 
 export const meta = () => {
   return [
@@ -15,17 +11,20 @@ export const meta = () => {
       name: 'description',
       content: `Browse a list of GBH Series and explore records on the American Archive of Public Broadcasting.`,
     },
+    ...Meta,
   ]
 }
 
-export const SeriesLink = ({ title, host }) => (<div>
-  <a
-    className="series-link"
-    href={`${host}/catalog?f[series_titles][]=${title}&q=+(contributing_organizations: WGBH(MA) OR producing_organizations: WGBH Educational Foundation)&f[access_types][]=all`}
-    target="_blank"
-  >
-    {title}
-  </a></div>
+export const SeriesLink = ({ title, host }) => (
+  <div>
+    <a
+      className="series-link"
+      href={`${host}/catalog?f[series_titles][]=${title}&q=+(contributing_organizations: WGBH(MA) OR producing_organizations: WGBH Educational Foundation)&f[access_types][]=all`}
+      target="_blank"
+    >
+      {title}
+    </a>
+  </div>
 )
 
 export default class Series extends Component {
@@ -42,25 +41,51 @@ export default class Series extends Component {
     this.setState({ aapb_host: window.ENV.AAPB_HOST })
   }
 
-  render(){
-
-    let alphabetLinks = Object.keys(seriesData).map( (letter, index) => { return (<a key={index} className="series-alphabet-link" href={ "#series-"+letter.toLowerCase() } >{ letter }</a>) } )
-
-    let seriesAlphaGroups = Object.keys(seriesData).map( (letter, index) => {
-      let seriesGroup = seriesData[letter]
-      if(this.state.seriesSearch.length > 0){
-        seriesGroup = seriesGroup.filter( (title) => title.toLowerCase().includes(this.state.seriesSearch) )
-      }
-      
-      seriesGroup = seriesGroup.map( (title, groupIndex) => { return <a key={groupIndex} className="series-link" href={ `${ this.state.aapb_host }/catalog?f[series_titles][]=${ title }&q=+(contributing_organizations: WGBH(MA) OR producing_organizations: WGBH Educational Foundation)&f[access_types][]=all` } >{ title }</a> })
-
-      if(seriesGroup.length > 0)
-      return(
-        <div key={index} className="series-group">
-          <div id={ "series-"+letter.toLowerCase() } className="series-group-letter">{ letter }</div>
-          { seriesGroup }
-        </div>
+  render() {
+    let alphabetLinks = Object.keys(seriesData).map((letter, index) => {
+      return (
+        <a
+          key={index}
+          className="series-alphabet-link"
+          href={'#series-' + letter.toLowerCase()}
+        >
+          {letter}
+        </a>
       )
+    })
+
+    let seriesAlphaGroups = Object.keys(seriesData).map((letter, index) => {
+      let seriesGroup = seriesData[letter]
+      if (this.state.seriesSearch.length > 0) {
+        seriesGroup = seriesGroup.filter(title =>
+          title.toLowerCase().includes(this.state.seriesSearch)
+        )
+      }
+
+      seriesGroup = seriesGroup.map((title, groupIndex) => {
+        return (
+          <a
+            key={groupIndex}
+            className="series-link"
+            href={`${this.state.aapb_host}/catalog?f[series_titles][]=${title}&q=+(contributing_organizations: WGBH(MA) OR producing_organizations: WGBH Educational Foundation)&f[access_types][]=all`}
+          >
+            {title}
+          </a>
+        )
+      })
+
+      if (seriesGroup.length > 0)
+        return (
+          <div key={index} className="series-group">
+            <div
+              id={'series-' + letter.toLowerCase()}
+              className="series-group-letter"
+            >
+              {letter}
+            </div>
+            {seriesGroup}
+          </div>
+        )
     })
 
     // seriesAlphaGroups = seriesAlphaGroups.filter( (sG) => sG.length > 0  )

--- a/app/routes/support-us.jsx
+++ b/app/routes/support-us.jsx
@@ -1,4 +1,5 @@
-import { renderPageTitleBar } from "../classes/pageHelpers"
+import { renderPageTitleBar } from '../classes/pageHelpers'
+import { Meta } from '../classes/meta'
 
 export const meta = () => {
   return [
@@ -9,16 +10,21 @@ export const meta = () => {
       name: 'description',
       content: `Help us preserve and provide access to GBH's historic collection of programs for years to come!`,
     },
+    ...Meta,
   ]
 }
 
 export default function SupportUs() {
-  let titleBar = renderPageTitleBar("Support Us", "https://s3.amazonaws.com/openvault.wgbh.org/carousel/BB50th_DSC_0384Wide.jpg", "Help us preserve and provide access to GBH's historic collection of programs for years to come!")
+  let titleBar = renderPageTitleBar(
+    'Support Us',
+    'https://s3.amazonaws.com/openvault.wgbh.org/carousel/BB50th_DSC_0384Wide.jpg',
+    "Help us preserve and provide access to GBH's historic collection of programs for years to come!"
+  )
 
   return (
     <div>
       <div className="page-container">
-        { titleBar }
+        {titleBar}
 
         <div className="page-sidebar" />
 
@@ -27,36 +33,66 @@ export default function SupportUs() {
             <h2>Support Open Vault</h2>
 
             <div className="purple blockquote-text bold">
-              "GBH has created an unparalleled public media archive with over 350,000 master-level materials on various formats including videotape, film and audiotape. These materials, many vulnerable to complete deterioration, must be preserved and digitized so that they can be available for future generations. We are literally in a race against time.""
+              "GBH has created an unparalleled public media archive with over
+              350,000 master-level materials on various formats including
+              videotape, film and audiotape. These materials, many vulnerable to
+              complete deterioration, must be preserved and digitized so that
+              they can be available for future generations. We are literally in
+              a race against time.""
             </div>
-            <div className="small-text purple spaced">— Karen Cariani, David O. Ives Executive Director, GBH Archives</div>
+            <div className="small-text purple spaced">
+              — Karen Cariani, David O. Ives Executive Director, GBH Archives
+            </div>
 
             <h2>NEH Challenge</h2>
 
             <p>
-              In 2018, GBH received a $750,000 challenge grant from the National Endowment for the Humanities (NEH) to preserve and digitize the most at-risk items in the GBH archival collection, specifically 83,000 media resources. This effort will preserve the archive we have built and ensure that future media assets are properly preserved as they are created. The grant calls for a 4:1 match, or $3 million in matching dollars over the next four years.
+              In 2018, GBH received a $750,000 challenge grant from the National
+              Endowment for the Humanities (NEH) to preserve and digitize the
+              most at-risk items in the GBH archival collection, specifically
+              83,000 media resources. This effort will preserve the archive we
+              have built and ensure that future media assets are properly
+              preserved as they are created. The grant calls for a 4:1 match, or
+              $3 million in matching dollars over the next four years.
             </p>
 
             <div className="med-textline">
-              A gift in support of Open Vault, leveraged by the NEH Challenge grant currently underway, directly enables us to:
+              A gift in support of Open Vault, leveraged by the NEH Challenge
+              grant currently underway, directly enables us to:
             </div>
 
             <ul>
-              <li>Digitize critical programs that are currently deteriorating on obsolete formats</li>
+              <li>
+                Digitize critical programs that are currently deteriorating on
+                obsolete formats
+              </li>
               <li>Add newly digitized content to Open Vault</li>
-              <li>Improve our website with new features and improve functionality and discoverability of the collection</li>
-              <li>Sustain Open Vault technical infrastructure so that we can continue to provide online access to the collection</li>
+              <li>
+                Improve our website with new features and improve functionality
+                and discoverability of the collection
+              </li>
+              <li>
+                Sustain Open Vault technical infrastructure so that we can
+                continue to provide online access to the collection
+              </li>
             </ul>
 
-            <div className="static-link blockquote-text bold">Read the entire case for support <a href="https://s3.amazonaws.com/openvault.wgbh.org/resources/case_for_support.pdf">here.</a></div>
-
-
-            <div className="med-textline">
-              If you are interested in supporting Open Vault and the NEH challenge currently underway, please contact Tatiana Espinal, Major Gifts Officer, at tatiana_espinal@wgbh.org or 617.300.3677.
+            <div className="static-link blockquote-text bold">
+              Read the entire case for support{' '}
+              <a href="https://s3.amazonaws.com/openvault.wgbh.org/resources/case_for_support.pdf">
+                here.
+              </a>
             </div>
 
             <div className="med-textline">
-              GBH is a 501(c)(3) nonprofit organization. All donations are tax deductible to the extent allowable by law.
+              If you are interested in supporting Open Vault and the NEH
+              challenge currently underway, please contact Tatiana Espinal,
+              Major Gifts Officer, at tatiana_espinal@wgbh.org or 617.300.3677.
+            </div>
+
+            <div className="med-textline">
+              GBH is a 501(c)(3) nonprofit organization. All donations are tax
+              deductible to the extent allowable by law.
             </div>
           </div>
         </div>

--- a/app/routes/terms.jsx
+++ b/app/routes/terms.jsx
@@ -1,5 +1,5 @@
-import { Link, useLoaderData } from "@remix-run/react"
-import { renderPageTitleBar } from "../classes/pageHelpers"
+import { renderPageTitleBar } from '../classes/pageHelpers'
+import { Meta } from '../classes/meta'
 
 export const meta = () => {
   return [
@@ -10,135 +10,576 @@ export const meta = () => {
       name: 'description',
       content: `Terms and Conditions for using the GBH Open Vault website.`,
     },
+    ...Meta,
   ]
 }
 
 export default function Terms() {
-  let titleBar = renderPageTitleBar("Terms And Conditions", "https://s3.amazonaws.com/openvault.wgbh.org/carousel/DickPleasantsWide.jpeg")
+  let titleBar = renderPageTitleBar(
+    'Terms And Conditions',
+    'https://s3.amazonaws.com/openvault.wgbh.org/carousel/DickPleasantsWide.jpeg'
+  )
 
   return (
     <div>
       <div className="page-container">
-        { titleBar }
+        {titleBar}
 
         <div className="page-sidebar" />
 
         <div className="page-body-container">
           <div className="page-body">
             <h2>Terms and Conditions</h2>
-
-            <p>THE FOLLOWING TERMS AND CONDITIONS GOVERN YOUR USE OF THE SITE. PLEASE READ THESE TERMS OF USE CAREFULLY BEFORE USING THIS SITE. By using the Site, you agree to be bound by these Terms of Use and the Privacy Policy. If you do not agree to these Terms of Use and the Privacy Policy, please exit the Site and do not use the Site or any of its features.</p>
-
-            <p>This Open Vault site (including all services, features, functionality and content available through the openvault.wgbh.org domain name, collectively, the “Site”) is owned and operated by the WGBH Educational Foundation (“GBH”). The terms and conditions of use (the “Terms” or “Terms of Use”) set forth herein apply to all information, online communications, services, text, video, audio files, graphics, still images, links, or other material and content that is or becomes available on the Site or is otherwise offered through the Site (collectively, “Content”). By accessing or using the Site, you specifically agree to abide by these Terms and any modifications thereto. Any modifications, additions or deletions to these Terms of Use or the Privacy Policy shall be effective immediately upon posting. Your continued use of the Site following the posting of updated Terms of Use or an updated Privacy Policy will mean that you agree to those changes.</p>
-
+            <p>
+              THE FOLLOWING TERMS AND CONDITIONS GOVERN YOUR USE OF THE SITE.
+              PLEASE READ THESE TERMS OF USE CAREFULLY BEFORE USING THIS SITE.
+              By using the Site, you agree to be bound by these Terms of Use and
+              the Privacy Policy. If you do not agree to these Terms of Use and
+              the Privacy Policy, please exit the Site and do not use the Site
+              or any of its features.
+            </p>
+            <p>
+              This Open Vault site (including all services, features,
+              functionality and content available through the openvault.wgbh.org
+              domain name, collectively, the “Site”) is owned and operated by
+              the WGBH Educational Foundation (“GBH”). The terms and conditions
+              of use (the “Terms” or “Terms of Use”) set forth herein apply to
+              all information, online communications, services, text, video,
+              audio files, graphics, still images, links, or other material and
+              content that is or becomes available on the Site or is otherwise
+              offered through the Site (collectively, “Content”). By accessing
+              or using the Site, you specifically agree to abide by these Terms
+              and any modifications thereto. Any modifications, additions or
+              deletions to these Terms of Use or the Privacy Policy shall be
+              effective immediately upon posting. Your continued use of the Site
+              following the posting of updated Terms of Use or an updated
+              Privacy Policy will mean that you agree to those changes.
+            </p>
             <p>A. Registration</p>
-
-            <p>Certain components, portions, features, or services available on the Site may, now or in the future, only be accessible and used after registration and creation of an account. When creating your account, you must provide true, accurate, and complete information, and maintain and promptly update this information. If you provide any information that is deceptive, untrue, inaccurate, or incomplete, or if GBH has reasonable grounds to suspect that the information is untrue, inaccurate, or incomplete, GBH has the right to suspend or terminate your account and access to the Site. You will provide a password and login name upon completing the registration process. You are responsible for maintaining the confidentiality of your password and login name, and are solely responsible for all activities that occur with your password and login name. You must immediately notify GBH of any unauthorized use of your account or any other breach of security. GBH will not be liable for any losses (including your or third party losses) caused by any unauthorized use of your account. You are responsible for obtaining access to the Site, which access may involve third party fees (such as Internet service provider charges). In addition, you must provide and are responsible for all equipment necessary to access the Site.</p>
-
-            <p>B. Restrictions on Use of Site and Content where Registration is Required</p>
-
+            <p>
+              Certain components, portions, features, or services available on
+              the Site may, now or in the future, only be accessible and used
+              after registration and creation of an account. When creating your
+              account, you must provide true, accurate, and complete
+              information, and maintain and promptly update this information. If
+              you provide any information that is deceptive, untrue, inaccurate,
+              or incomplete, or if GBH has reasonable grounds to suspect that
+              the information is untrue, inaccurate, or incomplete, GBH has the
+              right to suspend or terminate your account and access to the Site.
+              You will provide a password and login name upon completing the
+              registration process. You are responsible for maintaining the
+              confidentiality of your password and login name, and are solely
+              responsible for all activities that occur with your password and
+              login name. You must immediately notify GBH of any unauthorized
+              use of your account or any other breach of security. GBH will not
+              be liable for any losses (including your or third party losses)
+              caused by any unauthorized use of your account. You are
+              responsible for obtaining access to the Site, which access may
+              involve third party fees (such as Internet service provider
+              charges). In addition, you must provide and are responsible for
+              all equipment necessary to access the Site.
+            </p>
+            <p>
+              B. Restrictions on Use of Site and Content where Registration is
+              Required
+            </p>
             <ul className="numbered-list">
-              <li><p>You must be at least eighteen (18) years of age, be an emancipated minor, or, if over the age of 13, have the permission of your parent(s) or legal guardian(s), to register for certain features of the Site; and/or submit any User Generated Content (defined below) or personally-identifying information on or through the Site. If you are under 13 years of age, please do not send any information about yourself, including your name, address or email address. If we discover that we have collected any personally-identifying information from a child under the age of 13, we will remove that information from our database as soon as possible.</p></li>
+              <li>
+                <p>
+                  You must be at least eighteen (18) years of age, be an
+                  emancipated minor, or, if over the age of 13, have the
+                  permission of your parent(s) or legal guardian(s), to register
+                  for certain features of the Site; and/or submit any User
+                  Generated Content (defined below) or personally-identifying
+                  information on or through the Site. If you are under 13 years
+                  of age, please do not send any information about yourself,
+                  including your name, address or email address. If we discover
+                  that we have collected any personally-identifying information
+                  from a child under the age of 13, we will remove that
+                  information from our database as soon as possible.
+                </p>
+              </li>
 
-              <li><p>Non-commercial, Personal Use Only. This Site and the Content therein may be used for bona fide personal, educational, non-commercial purposes only. You may not use this Content in a defamatory, derogatory or offensive manner. In addition, you may not use the Content for or in any commercial or for-profit manner without the prior written consent of GBH. For clarity, this means the Content may not be used in any commercial tie-in (i.e. use of the Content in connection with marketing merchandise or services and/or in connection with premiums or promotions, or use of the Site or Content in order to gain advertising or subscription revenue), you may not charge anyone for the Content (e.g. charge for access to the Site or Content from another site), you may not incorporate the Content into a product that you sell or exchange in return for consideration of any kind (e.g. selling ads on another site targeted to the Site or Content), you may not use the Content to advertise or promote a product, nor may you use the Content in any other manner that may be construed as an endorsement, express or implied, of any person, party, product, or other entity.</p></li>
+              <li>
+                <p>
+                  Non-commercial, Personal Use Only. This Site and the Content
+                  therein may be used for bona fide personal, educational,
+                  non-commercial purposes only. You may not use this Content in
+                  a defamatory, derogatory or offensive manner. In addition, you
+                  may not use the Content for or in any commercial or for-profit
+                  manner without the prior written consent of GBH. For clarity,
+                  this means the Content may not be used in any commercial
+                  tie-in (i.e. use of the Content in connection with marketing
+                  merchandise or services and/or in connection with premiums or
+                  promotions, or use of the Site or Content in order to gain
+                  advertising or subscription revenue), you may not charge
+                  anyone for the Content (e.g. charge for access to the Site or
+                  Content from another site), you may not incorporate the
+                  Content into a product that you sell or exchange in return for
+                  consideration of any kind (e.g. selling ads on another site
+                  targeted to the Site or Content), you may not use the Content
+                  to advertise or promote a product, nor may you use the Content
+                  in any other manner that may be construed as an endorsement,
+                  express or implied, of any person, party, product, or other
+                  entity.
+                </p>
+              </li>
 
-              <li><p>You may not remove, copy, alter, reproduce, modify, create derivative works of, republish, post, publicly perform, publicly display, broadcast, download, transmit, distribute, license or commercially exploit, in whole or in part, the Content or this Site, except as expressly permitted by these Terms, the functionality of the Site, or, if applicable, by the respective content owner as indicated in any end user license agreement, if any, that accompanies such Content, provided that you include without modification all copyright and other proprietary notices contained in the Content.</p></li>
+              <li>
+                <p>
+                  You may not remove, copy, alter, reproduce, modify, create
+                  derivative works of, republish, post, publicly perform,
+                  publicly display, broadcast, download, transmit, distribute,
+                  license or commercially exploit, in whole or in part, the
+                  Content or this Site, except as expressly permitted by these
+                  Terms, the functionality of the Site, or, if applicable, by
+                  the respective content owner as indicated in any end user
+                  license agreement, if any, that accompanies such Content,
+                  provided that you include without modification all copyright
+                  and other proprietary notices contained in the Content.
+                </p>
+              </li>
 
-              <li><p>You may not circumvent, disable or otherwise interfere with security- related features of the Site or features that prevent or restrict use or copying of any Content. You further agree not to reverse engineer or jeopardize the correct functioning of the Site or attempt to gain access to secured portions of the Site to which you do not possess access rights.</p></li>
+              <li>
+                <p>
+                  You may not circumvent, disable or otherwise interfere with
+                  security- related features of the Site or features that
+                  prevent or restrict use or copying of any Content. You further
+                  agree not to reverse engineer or jeopardize the correct
+                  functioning of the Site or attempt to gain access to secured
+                  portions of the Site to which you do not possess access
+                  rights.
+                </p>
+              </li>
 
-              <li><p>You may not collect or harvest any personally identifiable information from the Site, nor use the communications system provided by the Site (e.g. tags, annotations, comments) for any advertising, promotion or solicitation purposes, regardless of whether or not this is for commercial or non-profit purposes.</p></li>
+              <li>
+                <p>
+                  You may not collect or harvest any personally identifiable
+                  information from the Site, nor use the communications system
+                  provided by the Site (e.g. tags, annotations, comments) for
+                  any advertising, promotion or solicitation purposes,
+                  regardless of whether or not this is for commercial or
+                  non-profit purposes.
+                </p>
+              </li>
 
-              <li><p>You may not use the Site to generate unsolicited email advertisements or spam, to conduct or promote any illegal activity, for political campaigning, or soliciting support for legislative or other initiatives.</p></li>
+              <li>
+                <p>
+                  You may not use the Site to generate unsolicited email
+                  advertisements or spam, to conduct or promote any illegal
+                  activity, for political campaigning, or soliciting support for
+                  legislative or other initiatives.
+                </p>
+              </li>
 
-              <li><p>You understand that when using the Site, you will be exposed to User Generated Content (defined below) from a variety of sources, and that GBH is not responsible for the accuracy, usefulness, safety, or intellectual property rights of or relating to such User Generated Content. Though GBH expects all users to adhere to our Terms and content policies, you understand and acknowledge that you may be exposed to User Generated Content that is inaccurate, offensive, indecent, or objectionable, and you agree to waive, and hereby do waive, any legal or equitable rights or remedies you have or may have against GBH and our affiliates with respect thereto, and agree to defend, indemnify and hold GBH, and its affiliates, and/or licensors, and their respective trustees, directors and employees, harmless to the fullest extent allowed by law regarding all matters related to your use of the Site.</p></li>
+              <li>
+                <p>
+                  You understand that when using the Site, you will be exposed
+                  to User Generated Content (defined below) from a variety of
+                  sources, and that GBH is not responsible for the accuracy,
+                  usefulness, safety, or intellectual property rights of or
+                  relating to such User Generated Content. Though GBH expects
+                  all users to adhere to our Terms and content policies, you
+                  understand and acknowledge that you may be exposed to User
+                  Generated Content that is inaccurate, offensive, indecent, or
+                  objectionable, and you agree to waive, and hereby do waive,
+                  any legal or equitable rights or remedies you have or may have
+                  against GBH and our affiliates with respect thereto, and agree
+                  to defend, indemnify and hold GBH, and its affiliates, and/or
+                  licensors, and their respective trustees, directors and
+                  employees, harmless to the fullest extent allowed by law
+                  regarding all matters related to your use of the Site.
+                </p>
+              </li>
 
-              <li><p>GBH reserves all rights not expressly granted in and to the Site and the Content.</p></li>
+              <li>
+                <p>
+                  GBH reserves all rights not expressly granted in and to the
+                  Site and the Content.
+                </p>
+              </li>
             </ul>
-
             <p>C. User Generated Content:</p>
-
-            <p>This Site may now or in the future permit the submission of videos, images, textual content (e.g., comments, tags, annotations) or other content submitted by you and other users (“User Generated Content”) and the hosting, sharing and/or publishing of such User Generated Content. You understand that whether or not such User Generated Content is published, GBH does not guarantee confidentiality with respect to any such User Generated Content. You acknowledge that User Generated Content may be routed through our servers, the servers of one or more third parties on our behalf, and the Internet, and may be viewed by GBH staff and on the Internet by the general public. You acknowledge that the Site, including its features, is for public and not private communications.</p>
-
-            <p>You shall be solely responsible for your own User Generated Content and the consequences of GBH posting, publishing or otherwise distributing them. By submitting your User Generated Content to the Site, you affirm, represent, and/or warrant that: (i) you own or have the necessary licenses, rights, consents, and permissions to upload, use and authorize GBH to use all patent, trademark, trade secret, copyright or other proprietary rights, including privacy and publicity rights, in and to any and all User Generated Content to enable inclusion, distribution and use of the User Generated Content in the manner contemplated by the Site and these Terms; (ii) you have the written consent, release, and/or permission of each and every identifiable individual person in the User Generated Content to use the name or likeness of each and every such identifiable individual person to enable inclusion, distribution and use of the User Generated Content in the manner contemplated by the Site and these Terms; (iii) the User Generated Content is your own original work and that you own or control the necessary rights to enable inclusion, distribution and use of the User Generated Content in the manner contemplated by the Site and these Terms; (iv) the User Generated Content does not in any way violate any laws, rules or regulations, (v) the User Generated Content is not in any way derogatory, abusive, defamatory, invasive of privacy or publicity rights, harmful to children, vulgar, profane, lewd, obscene, offensive, pornographic, threatening, harassing, violent, racist, or hateful, nor does it encourage conduct that would be considered a criminal offense, or give rise to civil liability; (vi) the User Generated Content does not violate or infringe upon the rights of any person or entity whatsoever; (vii) the User Generated Content is not an endorsement, express or implied, of any party, product, or other entity and (viii) you have not received payment or consideration of any kind for submitting the User Generated Content to GBH or the Site.</p>
-
-            <p>Unless you enter into a separate written agreement with GBH, GBH does not claim ownership in User Generated Content you submit; however, by submitting the User Generated Content to GBH, you hereby waive any and all moral rights in connection with the User Generated Content and you automatically grant GBH and its licensees, a perpetual, worldwide, non-exclusive, royalty-free, and transferable license to use, reproduce, distribute, sub-license, modify, create derivative works of (including without limitation, to rename, edit, shorten, if video – split the videos into different segments, and use the entire User Generated Content or segments thereof), publish, transfer, transmit, publicly display, publicly perform, host, index, cache, tag, encode, and/or adapt the User Generated Content in any and all media formats and channels, including, but not limited to, the Site (including the advertisement and promotion thereof), third party licensee web sites, over the air (on radio or television), and on mobile platforms, without payment and without further consent or notice to you. You further grant GBH and its licensees the right to contact you in connection with your User Generated Content and to use your name, city and state or province and other information that you have provided in connection with the User Generated Content.</p>
-
-            <p>You also hereby grant each user of the Site a non-exclusive license to access your User Generated Content through the Site, and to use, reproduce, distribute, create derivative works of, publish, transfer, transmit, publicly display and publicly perform such User Generated Content (in whole or in part) as permitted through the functionality of the Site and under these Terms.</p>
-
-            <p>In connection with your User Generated Content, you further agree that you will not upload content, or distribute anything that may be harmful to minors or that violates these Terms.</p>
-
-            <p>GBH does not endorse any User Generated Content or any opinion, recommendation, or advice expressed therein, and GBH expressly disclaims any and all liability in connection with User Generated Content. Opinions on the Site are not to be construed as assertions of fact.</p>
-
-            <p>By uploading User Generated Content, you are consenting to its display through the Site and for related promotional purposes.</p>
-
-            <p>You acknowledge that GBH reserves the right to screen, refuse to post, remove or edit User Generated Content at any time and for any or no reason in our absolute and sole discretion without prior notice, although we have no duty to do so. If we elect to screen User Generated Content, there may be a delay in the posting of such content to allow for a review process. If we have questions about your User Generated Content, we have the right, but not the duty, to contact you for further information, including, for example, to verify that you own the copyright or otherwise have the rights to post the User Generated Content.</p>
-
-            <p>GBH may terminate your access to the Site for uploading material in violation of these Terms, at any time, without prior notice and in its sole discretion.</p>
-
+            <p>
+              This Site may now or in the future permit the submission of
+              videos, images, textual content (e.g., comments, tags,
+              annotations) or other content submitted by you and other users
+              (“User Generated Content”) and the hosting, sharing and/or
+              publishing of such User Generated Content. You understand that
+              whether or not such User Generated Content is published, GBH does
+              not guarantee confidentiality with respect to any such User
+              Generated Content. You acknowledge that User Generated Content may
+              be routed through our servers, the servers of one or more third
+              parties on our behalf, and the Internet, and may be viewed by GBH
+              staff and on the Internet by the general public. You acknowledge
+              that the Site, including its features, is for public and not
+              private communications.
+            </p>
+            <p>
+              You shall be solely responsible for your own User Generated
+              Content and the consequences of GBH posting, publishing or
+              otherwise distributing them. By submitting your User Generated
+              Content to the Site, you affirm, represent, and/or warrant that:
+              (i) you own or have the necessary licenses, rights, consents, and
+              permissions to upload, use and authorize GBH to use all patent,
+              trademark, trade secret, copyright or other proprietary rights,
+              including privacy and publicity rights, in and to any and all User
+              Generated Content to enable inclusion, distribution and use of the
+              User Generated Content in the manner contemplated by the Site and
+              these Terms; (ii) you have the written consent, release, and/or
+              permission of each and every identifiable individual person in the
+              User Generated Content to use the name or likeness of each and
+              every such identifiable individual person to enable inclusion,
+              distribution and use of the User Generated Content in the manner
+              contemplated by the Site and these Terms; (iii) the User Generated
+              Content is your own original work and that you own or control the
+              necessary rights to enable inclusion, distribution and use of the
+              User Generated Content in the manner contemplated by the Site and
+              these Terms; (iv) the User Generated Content does not in any way
+              violate any laws, rules or regulations, (v) the User Generated
+              Content is not in any way derogatory, abusive, defamatory,
+              invasive of privacy or publicity rights, harmful to children,
+              vulgar, profane, lewd, obscene, offensive, pornographic,
+              threatening, harassing, violent, racist, or hateful, nor does it
+              encourage conduct that would be considered a criminal offense, or
+              give rise to civil liability; (vi) the User Generated Content does
+              not violate or infringe upon the rights of any person or entity
+              whatsoever; (vii) the User Generated Content is not an
+              endorsement, express or implied, of any party, product, or other
+              entity and (viii) you have not received payment or consideration
+              of any kind for submitting the User Generated Content to GBH or
+              the Site.
+            </p>
+            <p>
+              Unless you enter into a separate written agreement with GBH, GBH
+              does not claim ownership in User Generated Content you submit;
+              however, by submitting the User Generated Content to GBH, you
+              hereby waive any and all moral rights in connection with the User
+              Generated Content and you automatically grant GBH and its
+              licensees, a perpetual, worldwide, non-exclusive, royalty-free,
+              and transferable license to use, reproduce, distribute,
+              sub-license, modify, create derivative works of (including without
+              limitation, to rename, edit, shorten, if video – split the videos
+              into different segments, and use the entire User Generated Content
+              or segments thereof), publish, transfer, transmit, publicly
+              display, publicly perform, host, index, cache, tag, encode, and/or
+              adapt the User Generated Content in any and all media formats and
+              channels, including, but not limited to, the Site (including the
+              advertisement and promotion thereof), third party licensee web
+              sites, over the air (on radio or television), and on mobile
+              platforms, without payment and without further consent or notice
+              to you. You further grant GBH and its licensees the right to
+              contact you in connection with your User Generated Content and to
+              use your name, city and state or province and other information
+              that you have provided in connection with the User Generated
+              Content.
+            </p>
+            <p>
+              You also hereby grant each user of the Site a non-exclusive
+              license to access your User Generated Content through the Site,
+              and to use, reproduce, distribute, create derivative works of,
+              publish, transfer, transmit, publicly display and publicly perform
+              such User Generated Content (in whole or in part) as permitted
+              through the functionality of the Site and under these Terms.
+            </p>
+            <p>
+              In connection with your User Generated Content, you further agree
+              that you will not upload content, or distribute anything that may
+              be harmful to minors or that violates these Terms.
+            </p>
+            <p>
+              GBH does not endorse any User Generated Content or any opinion,
+              recommendation, or advice expressed therein, and GBH expressly
+              disclaims any and all liability in connection with User Generated
+              Content. Opinions on the Site are not to be construed as
+              assertions of fact.
+            </p>
+            <p>
+              By uploading User Generated Content, you are consenting to its
+              display through the Site and for related promotional purposes.
+            </p>
+            <p>
+              You acknowledge that GBH reserves the right to screen, refuse to
+              post, remove or edit User Generated Content at any time and for
+              any or no reason in our absolute and sole discretion without prior
+              notice, although we have no duty to do so. If we elect to screen
+              User Generated Content, there may be a delay in the posting of
+              such content to allow for a review process. If we have questions
+              about your User Generated Content, we have the right, but not the
+              duty, to contact you for further information, including, for
+              example, to verify that you own the copyright or otherwise have
+              the rights to post the User Generated Content.
+            </p>
+            <p>
+              GBH may terminate your access to the Site for uploading material
+              in violation of these Terms, at any time, without prior notice and
+              in its sole discretion.
+            </p>
             <p>D. Removal of Content</p>
-
-            <p>GBH does not permit the infringement of intellectual property rights, including copyright, on its Site, and GBH will remove Content (including User Generated Content) if properly notified that such Content infringes on another’s intellectual property rights. GBH reserves the right to remove Content, including User Generated Content without prior notice.</p>
-
-            <p>GBH reserves the right to change or discontinue temporarily or permanently any Content, or services available through the Site at any time without notice. GBH will not be liable to you or any third party for any modification or discontinuance of the services therein.</p>
-
-            <p>E. Conflicts: Some of the Content on the Site may now or in the future be made available under the specific terms of a license agreement. Where any matter contained in these Terms or elsewhere on this Site may be read so as to alter, amend or supersede any part of such license agreement, the license agreement shall be taken to be the definitive and over-ruling part of these Terms.</p>
-
-            <p>F. Copyright: All rights, including copyright and database right, in this Site and its Content (including all text, images, software, illustrations, artwork, high resolution photography, video clips, audio clips, any after-sales material, and ancillary materials) are owned by or licensed to GBH, or otherwise used by GBH as permitted by applicable law or agreement. In the case of User Generated Content, the contents are licensed to GBH by the user as set forth herein.</p>
-
-            <p>G. Trademarks: All trademarks, service marks, and trade names are proprietary to GBH, unless otherwise noted, in which case they are the trademarks, service marks, and/or trade names of the respective owner as indicated by the mark, as the case may be. All rights are reserved by the respective owners. You may not use any GBH-provided service marks, logos or graphics, without GBH’s prior written consent, except that you shall have the right, and obligation, to use any GBH or other content provider service mark or logo included in, or required to be used in connection with, Content or other functionalities of the Site, subject to the requirements set forth in these Terms for the use of the Content or other functionalities of the Site.</p>
-
-            <p>H. Users’ Obligation to Abide By Applicable Law: In connection with the use of the Site, you shall not engage in conduct or publish information which would infringe upon or injure the personal or property rights of any individual, group, or entity, including but not limited to defamation, harassment, invasion of privacy, tort, or disclosure of confidential or trade secrets. Furthermore, you shall not violate any law or treaty or intellectual property rights protected by law (such as copyright, patent and trademark rights). You acknowledge that the Content and materials available on the Site includes intellectual property that is protected under the copyright, trademark, and other intellectual property laws of the United States and/or other countries (“Intellectual Property Laws”). Such Intellectual Property Laws generally prohibit the unauthorized reproduction, distribution, or exhibition of all text, photographic and graphic (art and electronic) images, music, sound samplings, and other protected materials. The violation of applicable Intellectual Property Laws may give rise to civil and/or criminal penalties.</p>
-
+            <p>
+              GBH does not permit the infringement of intellectual property
+              rights, including copyright, on its Site, and GBH will remove
+              Content (including User Generated Content) if properly notified
+              that such Content infringes on another’s intellectual property
+              rights. GBH reserves the right to remove Content, including User
+              Generated Content without prior notice.
+            </p>
+            <p>
+              GBH reserves the right to change or discontinue temporarily or
+              permanently any Content, or services available through the Site at
+              any time without notice. GBH will not be liable to you or any
+              third party for any modification or discontinuance of the services
+              therein.
+            </p>
+            <p>
+              E. Conflicts: Some of the Content on the Site may now or in the
+              future be made available under the specific terms of a license
+              agreement. Where any matter contained in these Terms or elsewhere
+              on this Site may be read so as to alter, amend or supersede any
+              part of such license agreement, the license agreement shall be
+              taken to be the definitive and over-ruling part of these Terms.
+            </p>
+            <p>
+              F. Copyright: All rights, including copyright and database right,
+              in this Site and its Content (including all text, images,
+              software, illustrations, artwork, high resolution photography,
+              video clips, audio clips, any after-sales material, and ancillary
+              materials) are owned by or licensed to GBH, or otherwise used by
+              GBH as permitted by applicable law or agreement. In the case of
+              User Generated Content, the contents are licensed to GBH by the
+              user as set forth herein.
+            </p>
+            <p>
+              G. Trademarks: All trademarks, service marks, and trade names are
+              proprietary to GBH, unless otherwise noted, in which case they are
+              the trademarks, service marks, and/or trade names of the
+              respective owner as indicated by the mark, as the case may be. All
+              rights are reserved by the respective owners. You may not use any
+              GBH-provided service marks, logos or graphics, without GBH’s prior
+              written consent, except that you shall have the right, and
+              obligation, to use any GBH or other content provider service mark
+              or logo included in, or required to be used in connection with,
+              Content or other functionalities of the Site, subject to the
+              requirements set forth in these Terms for the use of the Content
+              or other functionalities of the Site.
+            </p>
+            <p>
+              H. Users’ Obligation to Abide By Applicable Law: In connection
+              with the use of the Site, you shall not engage in conduct or
+              publish information which would infringe upon or injure the
+              personal or property rights of any individual, group, or entity,
+              including but not limited to defamation, harassment, invasion of
+              privacy, tort, or disclosure of confidential or trade secrets.
+              Furthermore, you shall not violate any law or treaty or
+              intellectual property rights protected by law (such as copyright,
+              patent and trademark rights). You acknowledge that the Content and
+              materials available on the Site includes intellectual property
+              that is protected under the copyright, trademark, and other
+              intellectual property laws of the United States and/or other
+              countries (“Intellectual Property Laws”). Such Intellectual
+              Property Laws generally prohibit the unauthorized reproduction,
+              distribution, or exhibition of all text, photographic and graphic
+              (art and electronic) images, music, sound samplings, and other
+              protected materials. The violation of applicable Intellectual
+              Property Laws may give rise to civil and/or criminal penalties.
+            </p>
             <p>I. Notification of Copyright Infringement</p>
-
-            <p>If you are a copyright owner or an agent of a copyright owner and believe that any content on the Site infringes upon your copyrights, you may submit a notification to GBH’s Designated Agent pursuant to the Digital Millennium Copyright Act (“DMCA”) section 17 USC 512(c)(3). All notifications of claimed copyright infringement should be forwarded to our Designated Agent: Eric Brass, One Guest Street, Boston, MA 02135, fax: 617-300-1014, email: infringement@wgbh.org,</p>
-            According to Section 512(c)(3)(a), any copyright infringement notification must include:
-
-            <p>i. A physical or electronic signature of a person authorized to act on behalf of the owner of an exclusive right that is allegedly infringed;</p>
-
-            <p>ii. Identification of the copyrighted work claimed to have been infringed, or, if multiple copyrighted works at a single online site are covered by a single notification, a representative list of such works at that site;</p>
-
-            <p>iii. Identification of the material that is claimed to be infringing or to be the subject of infringing activity and that is to be removed or access to which is to be disabled, and information reasonably sufficient to permit the service provider to locate the material;</p>
-
-            <p>iv. Information reasonably sufficient to permit the service provider to contact the complaining party, such as an address, telephone number, and, if available, an electronic mail address at which the complaining party may be contacted;</p>
-
-            <p>v. A statement that the complaining party has a good faith belief that use of the material in the manner complained of is not authorized by the copyright owner, its agent, or the law; and</p>
-
-            <p>vi. A statement that the information in the notification is accurate, and under penalty of perjury, that the complaining party is authorized to act on behalf of the owner of an exclusive right that is allegedly infringed.</p>
-
-            <p>You acknowledge that if you fail to comply with all of the above requirements, your notice may not be valid pursuant to the DMCA.</p>
-
-            <p>Counter-Notice. If any of your User Generated Content has been removed or disabled because of a matter of possible copyright infringement, and you believe that your Content is not infringing or that you have the authorization from the copyright owner or the copyright owner’s agent, you may send a counter-notice containing the following information to the Designated Agent:</p>
+            <p>
+              If you are a copyright owner or an agent of a copyright owner and
+              believe that any content on the Site infringes upon your
+              copyrights, you may submit a notification to GBH’s Designated
+              Agent pursuant to the Digital Millennium Copyright Act (“DMCA”)
+              section 17 USC 512(c)(3). All notifications of claimed copyright
+              infringement should be forwarded to our Designated Agent: Eric
+              Brass, One Guest Street, Boston, MA 02135, fax: 617-300-1014,
+              email: infringement@wgbh.org,
+            </p>
+            According to Section 512(c)(3)(a), any copyright infringement
+            notification must include:
+            <p>
+              i. A physical or electronic signature of a person authorized to
+              act on behalf of the owner of an exclusive right that is allegedly
+              infringed;
+            </p>
+            <p>
+              ii. Identification of the copyrighted work claimed to have been
+              infringed, or, if multiple copyrighted works at a single online
+              site are covered by a single notification, a representative list
+              of such works at that site;
+            </p>
+            <p>
+              iii. Identification of the material that is claimed to be
+              infringing or to be the subject of infringing activity and that is
+              to be removed or access to which is to be disabled, and
+              information reasonably sufficient to permit the service provider
+              to locate the material;
+            </p>
+            <p>
+              iv. Information reasonably sufficient to permit the service
+              provider to contact the complaining party, such as an address,
+              telephone number, and, if available, an electronic mail address at
+              which the complaining party may be contacted;
+            </p>
+            <p>
+              v. A statement that the complaining party has a good faith belief
+              that use of the material in the manner complained of is not
+              authorized by the copyright owner, its agent, or the law; and
+            </p>
+            <p>
+              vi. A statement that the information in the notification is
+              accurate, and under penalty of perjury, that the complaining party
+              is authorized to act on behalf of the owner of an exclusive right
+              that is allegedly infringed.
+            </p>
+            <p>
+              You acknowledge that if you fail to comply with all of the above
+              requirements, your notice may not be valid pursuant to the DMCA.
+            </p>
+            <p>
+              Counter-Notice. If any of your User Generated Content has been
+              removed or disabled because of a matter of possible copyright
+              infringement, and you believe that your Content is not infringing
+              or that you have the authorization from the copyright owner or the
+              copyright owner’s agent, you may send a counter-notice containing
+              the following information to the Designated Agent:
+            </p>
             i. A physical or electronic signature of the subscriber.
-
-            <p>ii. Identification of the material that has been removed or to which access has been disabled and the location at which the material appeared before it was removed or access to it was disabled.</p>
-
-            <p>iii. A statement under penalty of perjury that you have a good faith belief that the material was removed or disabled as a result of mistake or misidentification of the material to be removed or disabled.</p>
-
-            <p>iv. Your name, address, and telephone number, and a statement that you consent to the jurisdiction of the Federal District Court for Boston, Massachusetts for the resolution of any copyright or other claims arising out of your use of the Site or under the Terms, and a statement that you accept service of process from the person who provided notification of the alleged infringement.</p>
-
-            <p>J. Disclosure of Online Communications: You are cautioned that any online communications may not be fully confidential. In addition, you should be aware that federal postal regulations do not protect electronic mail. You should be aware that some administrative personnel of GBH may, in the course of their regular duties, have access to communications required by law.</p>
-
-            <p>K. Rogue Programming and Viruses: GBH is not responsible for any computer virus, trojan horse, timebomb, worm, or any other rogue programming (“Rogue Programming”) that may be contained in any of the Content (including User Generated Content), material or software contained on the Site. GBH has no obligation to detect the presence of any Rogue Programming. Any downloading of software or other materials or any other use of the Content (including User Generated Content) on the Site is at your risk, and you are advised to take adequate precautions to minimize any loss to your system caused by Rogue Programming, including use of anti-virus programs and proper backup of files. You agree not to post, transmit, or make available in any way through the Site any software or other materials that contain Rogue Programming.</p>
-
-            <p>L. Content of Information: You are responsible for the content of any information you put on the Site. GBH has no obligation to, and does not in the normal course, monitor, prescreen or control any User Generated Content that is or becomes available on the Site. GBH reserves the right to review any User Generated Content that is or becomes available on the Site. GBH also reserves the right to refuse to post, to redact, edit or to move or remove any User Generated Content that is, in GBH’s sole discretion, unacceptable, undesirable, or in violation of these Terms. However, GBH has no obligation to exercise such reservations of rights by GBH and is not responsible for any failure or delay in removing such material.</p>
-
-            <p>M. Disclaimer of Warranties: The Site, the Content and other material on the Site are provided on an “As Is” basis without warranties of any kind, either express or implied, including without limitation warranties of title, non-infringement, or implied warranties of merchantability or fitness for a particular purpose. GBH does not warrant that any Content is complete or accurate, that the Site will be uninterrupted or error free, or that any Content or material is free of Rogue Programming.</p>
-
-            <p>N. Limitation of Damages: Under no circumstance, including negligence or any other legal theory, shall GBH be liable for any direct, indirect, incidental, special, punitive, or consequential damages that may result from the use or inability to use the Site, including without limitation use of or reliance on Content available on the Site, interruptions, errors, defects, mistakes, omissions, deletions of files, delays in operation or transmission, non-delivery of Content, disclosure of communications, or any other failure of performance.</p>
-
-            <p>O. Release and Indemnity: Though GBH expects all users to adhere to our content policies in these Terms, you may be exposed to content that violates our policies or is otherwise offensive through the use of the Site. Your use of the Site is at your own risk. You agree that GBH is not liable for content that is provided by others. We take no responsibility for your exposure to content on the Site whether it violates our content policies or not. You understand that the information and opinions in content uploaded by third parties represent solely the thoughts of the author and is neither endorsed by nor does it necessarily reflect GBH’s beliefs or editorial positions. You hereby release and waive any and all claims, causes of action and/or liability against GBH arising from or in connection with your use of the Site, the Content and/or any other material on the Site. You also agree to defend, indemnify, and hold harmless GBH and its trustees, officers and employees from and against any and all causes of action, claims or liability, including costs and attorneys fees, arising from or in connection with your use of the Site, your provision of User Generated Content to or on the Site, or failure to abide by applicable law or these Terms.</p>
-
-            <p>P. Modifications: These Terms and the Content may be revised, amended, or supplemented by GBH without notice at any time for any reason. Continuing to use the Site after a change has been made will signify your acceptance of the changes. You should refer back to this page for future updates.</p>
-
-            <p>Q. Privacy Policy. The Site’s Privacy Policy provides additional terms and conditions that apply to your use of our Site. If you do not agree to the conditions therein, please do not use the Site.</p>
-
-            <p>R. Other: These Terms will be governed by and interpreted in the English language pursuant to the laws of the Commonwealth of Massachusetts, United States of America, without giving effect to any principles of conflicts of law. If any provision of these Terms shall be unlawful, void, or for any reason, unenforceable then that provision shall be deemed severable from these Terms and shall not effect the validity and enforceability of any remaining provisions. You expressly agree that any dispute arising under these Terms shall be brought solely and exclusively before the state or federal courts located in Massachusetts and you waive any claim that this forum is or may be inconvenient or improper.</p>
-
-            <p>S. International Users: The Site is controlled and operated within the United States. GBH makes no representation that Content, materials or products available on or through the Site are appropriate or available for use outside of the United States. If you access the Site from a location outside the United States, you are responsible for compliance with applicable laws, including local laws regarding online conduct and content and U.S. export laws and regulations.</p>
-
+            <p>
+              ii. Identification of the material that has been removed or to
+              which access has been disabled and the location at which the
+              material appeared before it was removed or access to it was
+              disabled.
+            </p>
+            <p>
+              iii. A statement under penalty of perjury that you have a good
+              faith belief that the material was removed or disabled as a result
+              of mistake or misidentification of the material to be removed or
+              disabled.
+            </p>
+            <p>
+              iv. Your name, address, and telephone number, and a statement that
+              you consent to the jurisdiction of the Federal District Court for
+              Boston, Massachusetts for the resolution of any copyright or other
+              claims arising out of your use of the Site or under the Terms, and
+              a statement that you accept service of process from the person who
+              provided notification of the alleged infringement.
+            </p>
+            <p>
+              J. Disclosure of Online Communications: You are cautioned that any
+              online communications may not be fully confidential. In addition,
+              you should be aware that federal postal regulations do not protect
+              electronic mail. You should be aware that some administrative
+              personnel of GBH may, in the course of their regular duties, have
+              access to communications required by law.
+            </p>
+            <p>
+              K. Rogue Programming and Viruses: GBH is not responsible for any
+              computer virus, trojan horse, timebomb, worm, or any other rogue
+              programming (“Rogue Programming”) that may be contained in any of
+              the Content (including User Generated Content), material or
+              software contained on the Site. GBH has no obligation to detect
+              the presence of any Rogue Programming. Any downloading of software
+              or other materials or any other use of the Content (including User
+              Generated Content) on the Site is at your risk, and you are
+              advised to take adequate precautions to minimize any loss to your
+              system caused by Rogue Programming, including use of anti-virus
+              programs and proper backup of files. You agree not to post,
+              transmit, or make available in any way through the Site any
+              software or other materials that contain Rogue Programming.
+            </p>
+            <p>
+              L. Content of Information: You are responsible for the content of
+              any information you put on the Site. GBH has no obligation to, and
+              does not in the normal course, monitor, prescreen or control any
+              User Generated Content that is or becomes available on the Site.
+              GBH reserves the right to review any User Generated Content that
+              is or becomes available on the Site. GBH also reserves the right
+              to refuse to post, to redact, edit or to move or remove any User
+              Generated Content that is, in GBH’s sole discretion, unacceptable,
+              undesirable, or in violation of these Terms. However, GBH has no
+              obligation to exercise such reservations of rights by GBH and is
+              not responsible for any failure or delay in removing such
+              material.
+            </p>
+            <p>
+              M. Disclaimer of Warranties: The Site, the Content and other
+              material on the Site are provided on an “As Is” basis without
+              warranties of any kind, either express or implied, including
+              without limitation warranties of title, non-infringement, or
+              implied warranties of merchantability or fitness for a particular
+              purpose. GBH does not warrant that any Content is complete or
+              accurate, that the Site will be uninterrupted or error free, or
+              that any Content or material is free of Rogue Programming.
+            </p>
+            <p>
+              N. Limitation of Damages: Under no circumstance, including
+              negligence or any other legal theory, shall GBH be liable for any
+              direct, indirect, incidental, special, punitive, or consequential
+              damages that may result from the use or inability to use the Site,
+              including without limitation use of or reliance on Content
+              available on the Site, interruptions, errors, defects, mistakes,
+              omissions, deletions of files, delays in operation or
+              transmission, non-delivery of Content, disclosure of
+              communications, or any other failure of performance.
+            </p>
+            <p>
+              O. Release and Indemnity: Though GBH expects all users to adhere
+              to our content policies in these Terms, you may be exposed to
+              content that violates our policies or is otherwise offensive
+              through the use of the Site. Your use of the Site is at your own
+              risk. You agree that GBH is not liable for content that is
+              provided by others. We take no responsibility for your exposure to
+              content on the Site whether it violates our content policies or
+              not. You understand that the information and opinions in content
+              uploaded by third parties represent solely the thoughts of the
+              author and is neither endorsed by nor does it necessarily reflect
+              GBH’s beliefs or editorial positions. You hereby release and waive
+              any and all claims, causes of action and/or liability against GBH
+              arising from or in connection with your use of the Site, the
+              Content and/or any other material on the Site. You also agree to
+              defend, indemnify, and hold harmless GBH and its trustees,
+              officers and employees from and against any and all causes of
+              action, claims or liability, including costs and attorneys fees,
+              arising from or in connection with your use of the Site, your
+              provision of User Generated Content to or on the Site, or failure
+              to abide by applicable law or these Terms.
+            </p>
+            <p>
+              P. Modifications: These Terms and the Content may be revised,
+              amended, or supplemented by GBH without notice at any time for any
+              reason. Continuing to use the Site after a change has been made
+              will signify your acceptance of the changes. You should refer back
+              to this page for future updates.
+            </p>
+            <p>
+              Q. Privacy Policy. The Site’s Privacy Policy provides additional
+              terms and conditions that apply to your use of our Site. If you do
+              not agree to the conditions therein, please do not use the Site.
+            </p>
+            <p>
+              R. Other: These Terms will be governed by and interpreted in the
+              English language pursuant to the laws of the Commonwealth of
+              Massachusetts, United States of America, without giving effect to
+              any principles of conflicts of law. If any provision of these
+              Terms shall be unlawful, void, or for any reason, unenforceable
+              then that provision shall be deemed severable from these Terms and
+              shall not effect the validity and enforceability of any remaining
+              provisions. You expressly agree that any dispute arising under
+              these Terms shall be brought solely and exclusively before the
+              state or federal courts located in Massachusetts and you waive any
+              claim that this forum is or may be inconvenient or improper.
+            </p>
+            <p>
+              S. International Users: The Site is controlled and operated within
+              the United States. GBH makes no representation that Content,
+              materials or products available on or through the Site are
+              appropriate or available for use outside of the United States. If
+              you access the Site from a location outside the United States, you
+              are responsible for compliance with applicable laws, including
+              local laws regarding online conduct and content and U.S. export
+              laws and regulations.
+            </p>
             <p>Updated April 30, 2010</p>
-
           </div>
         </div>
       </div>

--- a/app/routes/visit-us.jsx
+++ b/app/routes/visit-us.jsx
@@ -1,5 +1,5 @@
-import { Link, useLoaderData } from "@remix-run/react"
-import { renderPageTitleBar } from "../classes/pageHelpers"
+import { renderPageTitleBar } from '../classes/pageHelpers'
+import { Meta } from '../classes/meta'
 
 export const meta = () => {
   return [
@@ -10,16 +10,21 @@ export const meta = () => {
       name: 'description',
       content: `Members of the general public are welcome to access the GBH Archives' collections in the GBH offices in Brighton, MA.`,
     },
+    ...Meta,
   ]
 }
 
 export default function VisitUs() {
-  let titleBar = renderPageTitleBar("Visit Us", "https://s3.amazonaws.com/openvault.wgbh.org/carousel/boston-tv-news-q-80.jpg", "Members of the general public are welcome to access the GBH Archives' collections in the GBH offices in Brighton, MA.")
+  let titleBar = renderPageTitleBar(
+    'Visit Us',
+    'https://s3.amazonaws.com/openvault.wgbh.org/carousel/boston-tv-news-q-80.jpg',
+    "Members of the general public are welcome to access the GBH Archives' collections in the GBH offices in Brighton, MA."
+  )
 
   return (
     <div>
       <div className="page-container">
-        { titleBar }
+        {titleBar}
 
         <div className="page-sidebar" />
 
@@ -28,7 +33,20 @@ export default function VisitUs() {
             <h2>Visiting the Archives</h2>
 
             <p className="static-section">
-              Members of the general public are welcome to access the GBH Archives' processed collections in the GBH offices in Brighton, Massachusetts. Users who visit the MLA must agree to abide by MLA's policies. Materials can only be accessed on-site and cannot be borrowed or taken from the GBH offices. The MLA is open Monday through Friday from 10:00am to 4:00pm ET. Before contacting us to schedule your visit, please review the information below. Before your visit, researchers should contact MLA with a specific research request. In some cases, we may first request to schedule an interview to determine which materials you will need to access. Researchers are asked to plan their visit well in advance so that some reference services can be conducted prior to arrival, such as retrieving boxes and tapes. Researchers must contact MLA a minimum of two weeks in advance of their intended visit.
+              Members of the general public are welcome to access the GBH
+              Archives' processed collections in the GBH offices in Brighton,
+              Massachusetts. Users who visit the MLA must agree to abide by
+              MLA's policies. Materials can only be accessed on-site and cannot
+              be borrowed or taken from the GBH offices. The MLA is open Monday
+              through Friday from 10:00am to 4:00pm ET. Before contacting us to
+              schedule your visit, please review the information below. Before
+              your visit, researchers should contact MLA with a specific
+              research request. In some cases, we may first request to schedule
+              an interview to determine which materials you will need to access.
+              Researchers are asked to plan their visit well in advance so that
+              some reference services can be conducted prior to arrival, such as
+              retrieving boxes and tapes. Researchers must contact MLA a minimum
+              of two weeks in advance of their intended visit.
             </p>
 
             <hr className="spaced-hr" />
@@ -37,42 +55,81 @@ export default function VisitUs() {
               <img src="https://s3.amazonaws.com/openvault.wgbh.org/logos/GBH_Archives_rgb_color.png" />
             </div>
             <div className="static-halfbox purple bold">
-              Please contact GBH Archives at archive_requests@wgbh.org and state the nature of your research interest and your academic or professional affiliation.
+              Please contact GBH Archives at archive_requests@wgbh.org and state
+              the nature of your research interest and your academic or
+              professional affiliation.
             </div>
 
             <h2>Guidelines</h2>
 
             <p className="static-section">
-              Individuals are only permitted to access fully processed parts of the GBH archival collections. User requests for restricted materials will be discussed with GBH's Legal Department to determine if the request can be honored. Researchers must abide by GBH Archives' rules governing the physical handling of archival materials such as: 
+              Individuals are only permitted to access fully processed parts of
+              the GBH archival collections. User requests for restricted
+              materials will be discussed with GBH's Legal Department to
+              determine if the request can be honored. Researchers must abide by
+              GBH Archives' rules governing the physical handling of archival
+              materials such as:
             </p>
 
             <ul>
               <li>using only pencil in the research area</li>
               <li>not using any screening or recording devices</li>
-              <li>leaving coats, bags, and briefcases outside of the room where they will be researching</li>
-              <li>agreeing to let MLA staff do all photocopying of archival papers</li>
-              <li>permitting an inspection of notes to ensure documents are not leaving the Archives</li>
+              <li>
+                leaving coats, bags, and briefcases outside of the room where
+                they will be researching
+              </li>
+              <li>
+                agreeing to let MLA staff do all photocopying of archival papers
+              </li>
+              <li>
+                permitting an inspection of notes to ensure documents are not
+                leaving the Archives
+              </li>
             </ul>
 
             <p className="static-section">
-              Permitted photocopying of materials for scholarly use will be granted in accordance with the Fair Use provisions of the Copyright Act.
+              Permitted photocopying of materials for scholarly use will be
+              granted in accordance with the Fair Use provisions of the
+              Copyright Act.
             </p>
 
             <p className="static-section">
-                Users cannot quote or publish materials from GBH archival collections without first obtaining the written permission of GBH Educational Foundation. Users must submit a copy of all portions of their intended final work with their request for permission. Researchers must agree to credit GBH Archives in any work which references, incorporates, or quotes MLA's materials and must provide GBH Archives with one copy of the finished work free of charge (such as a book, paper, thesis, article, or film). Permission to quote or publish archival materials is granted on a case-by-case basis and will require a written license agreement. User visits to GBH Archives will be scheduled according to the time sensitivity of a researcher's project.
+              Users cannot quote or publish materials from GBH archival
+              collections without first obtaining the written permission of GBH
+              Educational Foundation. Users must submit a copy of all portions
+              of their intended final work with their request for permission.
+              Researchers must agree to credit GBH Archives in any work which
+              references, incorporates, or quotes MLA's materials and must
+              provide GBH Archives with one copy of the finished work free of
+              charge (such as a book, paper, thesis, article, or film).
+              Permission to quote or publish archival materials is granted on a
+              case-by-case basis and will require a written license agreement.
+              User visits to GBH Archives will be scheduled according to the
+              time sensitivity of a researcher's project.
             </p>
 
             <h2>Fees</h2>
             <p className="static-section">
-              Researchers should keep in mind the following fees associated with using archival materials at GBH.
+              Researchers should keep in mind the following fees associated with
+              using archival materials at GBH.
             </p>
 
             <ul>
               <li>
-                <b>Duplication</b>: If any requested material requires reformatting, the researcher shall be responsible for transfer costs and the newly formatted version will remain at the GBH Archives. The GBH Archives will not provide a personal copy of the work for the researcher. Please be aware that due to legal restrictions and copyright issues, the GBH Archives is unable to provide researchers or the general public with personal copies of materials.
+                <b>Duplication</b>: If any requested material requires
+                reformatting, the researcher shall be responsible for transfer
+                costs and the newly formatted version will remain at the GBH
+                Archives. The GBH Archives will not provide a personal copy of
+                the work for the researcher. Please be aware that due to legal
+                restrictions and copyright issues, the GBH Archives is unable to
+                provide researchers or the general public with personal copies
+                of materials.
               </li>
               <li>
-                <b>Photocopying</b>: GBH Archives charges $0.25 per photocopy for a standard 8.5″ x 11″ page. If a researcher requires larger copies, or needs between 30 and 50 pages, a special fee may be arranged on-site at the Archives’ discretion.
+                <b>Photocopying</b>: GBH Archives charges $0.25 per photocopy
+                for a standard 8.5″ x 11″ page. If a researcher requires larger
+                copies, or needs between 30 and 50 pages, a special fee may be
+                arranged on-site at the Archives’ discretion.
               </li>
             </ul>
           </div>


### PR DESCRIPTION
# Open Graph
- Adds `og:*` meta tags
- Adds `twitter:*` tags
- Apply custom metadata from API

Closes #24